### PR TITLE
Removed user-facing log

### DIFF
--- a/src/httpRequest.ts
+++ b/src/httpRequest.ts
@@ -61,7 +61,6 @@ export function _request<T>(
         dgRes.on("end", () => {
           let dgResponse;
           try {
-            console.log(`content: ${dgResContent}`);
             dgResponse = JSON.parse(dgResContent);
           } catch (err) {
             dgResponse = { error: dgResContent };


### PR DESCRIPTION
Given this code snippet:

```js
deepgram.transcription.preRecorded({
	buffer: fs.readFileSync("./sample.wav"),
	mimetype: 'audio/wav'
}).then(transcription => {
	console.log(transcription)
})
```

Running the script on the terminal prints:

```
"content: RAW RESPONSE AS STRING"
{ actual response here }
```

This change removed that first raw print and only prints when and how the user wants.