### PR TITLE
Run all tests/linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "tsc -p ./",
     "coverage": "nyc npm run test",
-    "lint": "eslint ./src --ext .ts && prettier --config .prettierrc src/**/*.ts --write",
-    "test": "mocha -r ts-node/register tests/**/*test.ts --insect",
+    "lint": "eslint ./src --ext .ts && prettier --config .prettierrc src/*.ts src/**/*.ts --write",
+    "test": "mocha -r ts-node/register tests/*test.ts tests/**/*test.ts --insect",
     "watch": "nodemon -e ts --watch src --exec \"npm run build\""
   },
   "repository": {


### PR DESCRIPTION
The glob provided (`tests/**/*test.ts`) only matched tests in subfolders.
This means that any tests directly in the `tests` folder were being ignored.

The same is true for linting with `npm run lint`

This commit enables tests/linting for all files
