### PR TITLE
feat: add fetch override

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 import { isBrowser } from "./helpers";
+import { DeepgramClientOptions } from "./types/DeepgramClientOptions";
 import { FetchOptions } from "./types/Fetch";
 import { version } from "./version";
 
@@ -18,7 +19,7 @@ export const DEFAULT_FETCH_OPTIONS: FetchOptions = {
   headers: DEFAULT_HEADERS,
 };
 
-export const DEFAULT_OPTIONS = {
+export const DEFAULT_OPTIONS: DeepgramClientOptions = {
   global: DEFAULT_GLOBAL_OPTIONS,
-  fetch: DEFAULT_FETCH_OPTIONS,
+  fetchOptions: DEFAULT_FETCH_OPTIONS,
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,5 +21,5 @@ export const DEFAULT_FETCH_OPTIONS: FetchOptions = {
 
 export const DEFAULT_OPTIONS: DeepgramClientOptions = {
   global: DEFAULT_GLOBAL_OPTIONS,
-  fetchOptions: DEFAULT_FETCH_OPTIONS,
+  fetch: DEFAULT_FETCH_OPTIONS,
 };

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -2,9 +2,11 @@ import crossFetch from "cross-fetch";
 import { resolveHeadersConstructor } from "./helpers";
 import type { Fetch } from "./types/Fetch";
 
-export const resolveFetch = (): Fetch => {
+export const resolveFetch = (customFetch?: Fetch): Fetch => {
   let _fetch: Fetch;
-  if (typeof fetch === "undefined") {
+  if (customFetch) {
+    _fetch = customFetch;
+  } else if (typeof fetch === "undefined") {
     _fetch = crossFetch as unknown as Fetch;
   } else {
     _fetch = fetch;
@@ -12,8 +14,8 @@ export const resolveFetch = (): Fetch => {
   return (...args) => _fetch(...args);
 };
 
-export const fetchWithAuth = (apiKey: string): Fetch => {
-  const fetch = resolveFetch();
+export const fetchWithAuth = (apiKey: string, customFetch?: Fetch): Fetch => {
+  const fetch = resolveFetch(customFetch);
   const HeadersConstructor = resolveHeadersConstructor();
 
   return async (input, init) => {

--- a/src/lib/types/DeepgramClientOptions.ts
+++ b/src/lib/types/DeepgramClientOptions.ts
@@ -13,11 +13,8 @@ export interface DeepgramClientOptions {
     url?: string;
   };
   fetchOptions?: FetchOptions;
+  fetch?: Fetch;
   restProxy?: {
     url: null | string;
   };
-}
-
-export interface DeepgramClientOptionsWithFetchOverride extends DeepgramClientOptions {
-  fetch: Fetch;
 }

--- a/src/lib/types/DeepgramClientOptions.ts
+++ b/src/lib/types/DeepgramClientOptions.ts
@@ -1,4 +1,4 @@
-import { FetchOptions } from "./Fetch";
+import { Fetch, FetchOptions } from "./Fetch";
 
 export interface DeepgramClientOptions {
   global?: {
@@ -12,8 +12,12 @@ export interface DeepgramClientOptions {
      */
     url?: string;
   };
-  fetch?: FetchOptions;
+  fetchOptions?: FetchOptions;
   restProxy?: {
     url: null | string;
   };
+}
+
+export interface DeepgramClientOptionsWithFetchOverride extends DeepgramClientOptions {
+  fetch: Fetch;
 }

--- a/src/lib/types/DeepgramClientOptions.ts
+++ b/src/lib/types/DeepgramClientOptions.ts
@@ -12,8 +12,8 @@ export interface DeepgramClientOptions {
      */
     url?: string;
   };
-  fetchOptions?: FetchOptions;
-  fetch?: Fetch;
+  fetch?: FetchOptions;
+  customFetch?: Fetch;
   restProxy?: {
     url: null | string;
   };

--- a/src/lib/types/DeepgramClientOptions.ts
+++ b/src/lib/types/DeepgramClientOptions.ts
@@ -13,7 +13,7 @@ export interface DeepgramClientOptions {
     url?: string;
   };
   fetch?: FetchOptions;
-  customFetch?: Fetch;
+  _experimentalCustomFetch?: Fetch;
   restProxy?: {
     url: null | string;
   };

--- a/src/packages/AbstractRestfulClient.ts
+++ b/src/packages/AbstractRestfulClient.ts
@@ -18,7 +18,7 @@ export abstract class AbstractRestfulClient extends AbstractClient {
       );
     }
 
-    this.fetch = options.fetch ? options.fetch : fetchWithAuth(this.key);
+    this.fetch = fetchWithAuth(this.key, options.customFetch);
   }
 
   protected _getErrorMessage(err: any): string {
@@ -49,9 +49,9 @@ export abstract class AbstractRestfulClient extends AbstractClient {
     body?: string | Buffer | Readable
   ) {
     const params: { [k: string]: any } = {
-      ...this.options?.fetchOptions,
+      ...this.options?.fetch,
       method,
-      headers: { ...this.options?.fetchOptions?.headers, ...headers } || {},
+      headers: { ...this.options?.fetch?.headers, ...headers } || {},
     };
 
     if (method === "GET") {

--- a/src/packages/AbstractRestfulClient.ts
+++ b/src/packages/AbstractRestfulClient.ts
@@ -5,15 +5,11 @@ import type { Fetch, FetchParameters, RequestMethodType } from "../lib/types/Fet
 import { AbstractClient } from "./AbstractClient";
 import { DeepgramClientOptions } from "../lib/types";
 import { isBrowser } from "../lib/helpers";
-import { DeepgramClientOptionsWithFetchOverride } from "../lib/types/DeepgramClientOptions";
 
 export abstract class AbstractRestfulClient extends AbstractClient {
   protected fetch: Fetch;
 
-  constructor(
-    protected key: string,
-    protected options: DeepgramClientOptions | DeepgramClientOptionsWithFetchOverride
-  ) {
+  constructor(protected key: string, protected options: DeepgramClientOptions) {
     super(key, options);
 
     if (isBrowser() && !this._willProxy()) {
@@ -22,11 +18,7 @@ export abstract class AbstractRestfulClient extends AbstractClient {
       );
     }
 
-    if ("fetch" in options) {
-      this.fetch = options.fetch;
-    } else {
-      this.fetch = fetchWithAuth(this.key);
-    }
+    this.fetch = options.fetch ? options.fetch : fetchWithAuth(this.key);
   }
 
   protected _getErrorMessage(err: any): string {

--- a/src/packages/AbstractRestfulClient.ts
+++ b/src/packages/AbstractRestfulClient.ts
@@ -18,7 +18,7 @@ export abstract class AbstractRestfulClient extends AbstractClient {
       );
     }
 
-    this.fetch = fetchWithAuth(this.key, options.customFetch);
+    this.fetch = fetchWithAuth(this.key, options._experimentalCustomFetch);
   }
 
   protected _getErrorMessage(err: any): string {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,6 @@
 import { createClient } from "../src";
 import { DEFAULT_URL } from "../src/lib/constants";
-import { expect } from "chai";
+import { expect, assert } from "chai";
 import { faker } from "@faker-js/faker";
 import { stripTrailingSlash } from "../src/lib/helpers";
 import DeepgramClient from "../src/DeepgramClient";
@@ -81,5 +81,22 @@ describe("testing creation of a deepgram client object", () => {
     });
 
     expect(client).is.instanceOf(DeepgramClient);
+  });
+
+  it("should use custom fetch when provided", async () => {
+    const fetch = async () => {
+      return new Response(JSON.stringify({ customFetch: true }));
+    };
+
+    const client = createClient(faker.string.alphanumeric(40), {
+      global: { url: "https://api.mock.deepgram.com" },
+      _experimentalCustomFetch: fetch,
+    });
+
+    const { result, error } = await client.manage.getProjectBalances(faker.string.uuid());
+
+    assert.isNull(error);
+    assert.isNotNull(result);
+    assert.containsAllDeepKeys(result, ["customFetch"]);
   });
 });


### PR DESCRIPTION
This PR renames `fetch` to `fetchOptions` and adds an additional option to provide own fetch method. 

fixes #243 