### PR TITLE
fix: default URL should have protocol included

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_HEADERS = {
   "User-Agent": `@deepgram/sdk/${version}`,
 };
 
-export const DEFAULT_URL = "api.deepgram.com";
+export const DEFAULT_URL = "https://api.deepgram.com";
 
 export const DEFAULT_GLOBAL_OPTIONS = {
   url: DEFAULT_URL,


### PR DESCRIPTION
Small fix to the permanent warning when someone has not provided a custom URL (make the default URL not trigger the warning by adding a protocol).