### PR TITLE
Add missing expiration_date to CreateProjectKeyResponse type

### DIFF
--- a/src/lib/types/CreateProjectKeyResponse.ts
+++ b/src/lib/types/CreateProjectKeyResponse.ts
@@ -5,4 +5,5 @@ export interface CreateProjectKeyResponse {
   scopes: string[];
   tags?: string[];
   created: string;
+  expiration_date?: string;
 }


### PR DESCRIPTION
When creating ephemeral keys with a ttl, the API returns a response to `v1/projects/:projectId/keys` with an `expiration_date` param. This adds that response to the type. 