### PR TITLE
chore: simplify regex

### DIFF
--- a/src/packages/LiveClient.ts
+++ b/src/packages/LiveClient.ts
@@ -27,7 +27,7 @@ export class LiveClient extends AbstractWsClient {
     super(key, options);
 
     const url = new URL(endpoint, this.baseUrl);
-    url.protocol = url.protocol.toLowerCase().replace(/(http)(s)?/gi, "ws$2");
+    url.protocol = url.protocol.toLowerCase().replace(/^http/, "ws");
     appendSearchParams(url.searchParams, this.transcriptionOptions);
 
     this._socket = new w3cwebsocket(url.toString(), ["token", this.key]);


### PR DESCRIPTION
- We already do toLowerCase(), so don't need `i` flag.
- We're not using the http bit, so no need to capture it.
- If there's an s, append it, if not don't. This is the same as just replacing http with ws:
  - [http]:// -> [ws]://
  - [http]s:// -> [ws]s://
  - [http]x:// -> [ws]x:// -> error. Is ok.
  - [http]sx:// -> [ws]sx:// -> error in both. Is ok.
- We don't want to replace protocols that do not start with http, such as git+https, so we can anchor at string start and leave out the `g` flag.

Much simpler -:)