### PR TITLE
fix: unconditional process reference

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,7 @@ import { DeepgramClientOptions } from "./types/DeepgramClientOptions";
 import { FetchOptions } from "./types/Fetch";
 import { version } from "./version";
 
-export const NODE_VERSION = process.versions.node;
+export const NODE_VERSION = process?.versions.node || "Unknown";
 
 export const DEFAULT_HEADERS = {
   "Content-Type": `application/json`,


### PR DESCRIPTION
The `process` global does not exist in the browser and therefore throws an error if one tries to create a client in the browser.
Fix it in a way that's compatible with any (future) engine that doesn't have a process global.

closes #290 