### PR TITLE
fix: missing `speaker` type in SyncPrerecordedResponse 

### DIFF
--- a/src/lib/types/SyncPrerecordedResponse.ts
+++ b/src/lib/types/SyncPrerecordedResponse.ts
@@ -90,6 +90,7 @@ interface Paragraph {
   start: number;
   end: number;
   num_words: number;
+  speaker?: number;
 }
 
 interface ParagraphGroup {


### PR DESCRIPTION
will fixes this issue https://github.com/deepgram/deepgram-js-sdk/issues/260