### PR TITLE
fix: Resolve missing process variable in browser environment

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,10 @@ import { DeepgramClientOptions } from "./types/DeepgramClientOptions";
 import { FetchOptions } from "./types/Fetch";
 import { version } from "./version";
 
-export const NODE_VERSION = process?.versions?.node || "Unknown";
+export const NODE_VERSION =
+  typeof process === "undefined"
+    ? "Unknown"
+    : process?.versions?.node || "Unknown";
 
 export const DEFAULT_HEADERS = {
   "Content-Type": `application/json`,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,7 @@ import { DeepgramClientOptions } from "./types/DeepgramClientOptions";
 import { FetchOptions } from "./types/Fetch";
 import { version } from "./version";
 
-export const NODE_VERSION = process?.versions.node || "Unknown";
+export const NODE_VERSION = process?.versions?.node || "Unknown";
 
 export const DEFAULT_HEADERS = {
   "Content-Type": `application/json`,


### PR DESCRIPTION
Follow up to close #297 

- check if `process` is defined, else fall back to `Unknown`
- prevent the unlikely case of `process.versions` being defined without a `node` key, fall back to `Unknown`