### PR TITLE
CI: fail on test errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Run tests
         run: |
           npm clean-install
+          npm run test
+        
+      - name: Generate test coverage
+        run: |
           npm run test:coverage
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
While debugging another issue I noticed that there is actually a test failing but the CI is reporting all good. For example the last CI run https://github.com/deepgram/deepgram-js-sdk/actions/runs/9403306912/job/25899538297#step:4:120

I saw it's because the CI is only running the `npm run test:coverage` which doesn't seem to throw an error if there are test errors.

I thought the easiest fix is to just run the test separately to generating the coverage.