### PR TITLE
fix: missing type for detect_language which supports multiple strings OR a single bool

### DIFF
--- a/src/lib/types/TranscriptionSchema.ts
+++ b/src/lib/types/TranscriptionSchema.ts
@@ -149,7 +149,7 @@ interface PrerecordedSchema extends TranscriptionSchema {
   /**
    * @see https://developers.deepgram.com/docs/language-detection
    */
-  detect_language?: boolean;
+  detect_language?: boolean | string[];
 
   /**
    * @see https://developers.deepgram.com/docs/topic-detection


### PR DESCRIPTION
fixes #295 

adds missing type definition for restricting language detection to an array of language codes