### PR TITLE
fix: process is not defined in browser demos right now

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-import { convertProtocolToWs, isBrowser } from "./helpers";
+import { convertProtocolToWs, isBrowser, isBun, isNode } from "./helpers";
 import { version } from "./version";
 import type { DefaultNamespaceOptions, DefaultClientOptions } from "./types";
 
@@ -7,17 +7,32 @@ export const NODE_VERSION =
     ? process.versions.node
     : "unknown";
 
+export const BUN_VERSION =
+  typeof process !== "undefined" && process.versions && process.versions.bun
+    ? process.versions.bun
+    : "unknown";
+
 export const BROWSER_AGENT =
   typeof window !== "undefined" && window.navigator && window.navigator.userAgent
     ? window.navigator.userAgent
     : "unknown";
 
+const getAgent = () => {
+  if (isNode()) {
+    return `node/${NODE_VERSION}`;
+  } else if (isBun()) {
+    return `bun/${BUN_VERSION}`;
+  } else if (isBrowser()) {
+    return `javascript ${BROWSER_AGENT}`;
+  } else {
+    return `unknown`;
+  }
+};
+
 export const DEFAULT_HEADERS = {
   "Content-Type": `application/json`,
   "X-Client-Info": `@deepgram/sdk; ${isBrowser() ? "browser" : "server"}; v${version}`,
-  "User-Agent": `@deepgram/sdk/${version} ${
-    isBrowser() ? `javascript ${BROWSER_AGENT}` : `node/${NODE_VERSION}`
-  }`,
+  "User-Agent": `@deepgram/sdk/${version} ${getAgent()}`,
 };
 
 export const DEFAULT_URL = "https://api.deepgram.com";

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -11,14 +11,17 @@ import {
 import { Headers as CrossFetchHeaders } from "cross-fetch";
 import { Readable } from "stream";
 import merge from "deepmerge";
+import { BROWSER_AGENT, BUN_VERSION, NODE_VERSION } from "./constants";
 
 export function stripTrailingSlash(url: string): string {
   return url.replace(/\/$/, "");
 }
 
-export function isBrowser() {
-  return typeof window !== "undefined" && typeof window.document !== "undefined";
-}
+export const isBrowser = () => BROWSER_AGENT !== "unknown";
+
+export const isNode = () => NODE_VERSION !== "unknown";
+
+export const isBun = () => BUN_VERSION !== "unknown";
 
 export function applyDefaults<O, S>(options: Partial<O> = {}, subordinate: Partial<S> = {}): S {
   return merge(subordinate, options);

--- a/src/packages/AbstractLiveClient.ts
+++ b/src/packages/AbstractLiveClient.ts
@@ -2,6 +2,7 @@ import { AbstractClient, noop } from "./AbstractClient";
 import { CONNECTION_STATE, SOCKET_STATES } from "../lib/constants";
 import type { DeepgramClientOptions, LiveSchema } from "../lib/types";
 import type { WebSocket as WSWebSocket } from "ws";
+import { isBun } from "../lib/helpers";
 
 /**
  * Represents a constructor for a WebSocket-like object that can be used in the application.
@@ -125,7 +126,7 @@ export abstract class AbstractLiveClient extends AbstractClient {
      * @summary you can track the issue here
      * @link https://github.com/oven-sh/bun/issues/4529
      */
-    if (process?.versions?.bun) {
+    if (isBun()) {
       import("ws").then(({ default: WS }) => {
         this.conn = new WS(requestUrl, {
           headers: this.headers,
@@ -135,7 +136,7 @@ export abstract class AbstractLiveClient extends AbstractClient {
       });
       return;
     }
-    
+
     /**
      * Native websocket transport (browser)
      */


### PR DESCRIPTION
When testing the streaming example we found that the BUN changes had introduced a regression for the browser code.

*screams in isomorphic*