### PR TITLE
fix: move @types/node to dependencies instead of devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@deepgram/captions": "^1.1.1",
+        "@types/node": "^18.19.39",
         "cross-fetch": "^3.1.5",
         "deepmerge": "^4.3.1",
         "events": "^3.3.0",
@@ -22,7 +23,6 @@
         "@flydotio/dockerfile": "^0.4.10",
         "@types/chai": "^4.3.5",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^18.19.39",
         "@types/sinon": "^17.0.3",
         "@types/ws": "^8.5.10",
         "chai": "^4.3.7",
@@ -1203,7 +1203,6 @@
       "version": "18.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
       "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7133,7 +7132,6 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@deepgram/captions": "^1.1.1",
+    "@types/node": "^18.19.39",
     "cross-fetch": "^3.1.5",
     "deepmerge": "^4.3.1",
     "events": "^3.3.0",
@@ -64,7 +65,6 @@
     "@flydotio/dockerfile": "^0.4.10",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^18.19.39",
     "@types/sinon": "^17.0.3",
     "@types/ws": "^8.5.10",
     "chai": "^4.3.7",


### PR DESCRIPTION
Closes #309 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management by moving `@types/node` to the runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->