### PR TITLE
Fix errors under NextJS

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,21 +1,7 @@
-import { convertProtocolToWs, isBrowser, isBun, isNode } from "./helpers";
+import { convertProtocolToWs } from "./helpers";
+import { isBrowser, isBun, isNode, NODE_VERSION, BUN_VERSION, BROWSER_AGENT } from "./runtime";
 import { version } from "./version";
 import type { DefaultNamespaceOptions, DefaultClientOptions } from "./types";
-
-export const NODE_VERSION =
-  typeof process !== "undefined" && process.versions && process.versions.node
-    ? process.versions.node
-    : "unknown";
-
-export const BUN_VERSION =
-  typeof process !== "undefined" && process.versions && process.versions.bun
-    ? process.versions.bun
-    : "unknown";
-
-export const BROWSER_AGENT =
-  typeof window !== "undefined" && window.navigator && window.navigator.userAgent
-    ? window.navigator.userAgent
-    : "unknown";
 
 const getAgent = () => {
   if (isNode()) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -11,17 +11,10 @@ import {
 import { Headers as CrossFetchHeaders } from "cross-fetch";
 import { Readable } from "stream";
 import merge from "deepmerge";
-import { BROWSER_AGENT, BUN_VERSION, NODE_VERSION } from "./constants";
 
 export function stripTrailingSlash(url: string): string {
   return url.replace(/\/$/, "");
 }
-
-export const isBrowser = () => BROWSER_AGENT !== "unknown";
-
-export const isNode = () => NODE_VERSION !== "unknown";
-
-export const isBun = () => BUN_VERSION !== "unknown";
 
 export function applyDefaults<O, S>(options: Partial<O> = {}, subordinate: Partial<S> = {}): S {
   return merge(subordinate, options);

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -1,0 +1,20 @@
+export const NODE_VERSION =
+  typeof process !== "undefined" && process.versions && process.versions.node
+    ? process.versions.node
+    : "unknown";
+
+export const BUN_VERSION =
+  typeof process !== "undefined" && process.versions && process.versions.bun
+    ? process.versions.bun
+    : "unknown";
+
+export const BROWSER_AGENT =
+  typeof window !== "undefined" && window.navigator && window.navigator.userAgent
+    ? window.navigator.userAgent
+    : "unknown";
+
+export const isBrowser = () => BROWSER_AGENT !== "unknown";
+
+export const isNode = () => NODE_VERSION !== "unknown";
+
+export const isBun = () => BUN_VERSION !== "unknown";

--- a/src/packages/AbstractLiveClient.ts
+++ b/src/packages/AbstractLiveClient.ts
@@ -2,7 +2,7 @@ import { AbstractClient, noop } from "./AbstractClient";
 import { CONNECTION_STATE, SOCKET_STATES } from "../lib/constants";
 import type { DeepgramClientOptions, LiveSchema } from "../lib/types";
 import type { WebSocket as WSWebSocket } from "ws";
-import { isBun } from "../lib/helpers";
+import { isBun } from "../lib/runtime";
 
 /**
  * Represents a constructor for a WebSocket-like object that can be used in the application.

--- a/src/packages/AbstractRestClient.ts
+++ b/src/packages/AbstractRestClient.ts
@@ -4,7 +4,7 @@ import { fetchWithAuth, resolveResponse } from "../lib/fetch";
 import type { Fetch, FetchOptions, RequestMethodType } from "../lib/types/Fetch";
 import { AbstractClient } from "./AbstractClient";
 import { DeepgramClientOptions } from "../lib/types";
-import { isBrowser } from "../lib/helpers";
+import { isBrowser } from "../lib/runtime";
 import merge from "deepmerge";
 
 /**

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,13 +1,13 @@
-import { applyDefaults, convertProtocolToWs, isBrowser } from "../src/lib/helpers";
+import { applyDefaults, convertProtocolToWs } from "../src/lib/helpers";
 import {
   CONNECTION_STATE,
   DEFAULT_GLOBAL_OPTIONS,
   DEFAULT_HEADERS,
   DEFAULT_OPTIONS,
   DEFAULT_URL,
-  NODE_VERSION,
   SOCKET_STATES,
 } from "../src/lib/constants";
+import { isBrowser, NODE_VERSION } from "../src/lib/runtime";
 import { DeepgramClientOptions } from "../src/lib/types/DeepgramClientOptions";
 import { expect } from "chai";
 import { faker } from "@faker-js/faker";


### PR DESCRIPTION
This PR should fix some errors being shown when running the javascript sdk under NodeJS. I believe it was caused by a circular dependency that has been hence removed, as mentioned in issue #346 

I have locally tested both running `npm test` and running my application with its built version as module.

This is my first serious PR, feel free to let me know if I have something to improve on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new constants for environment detection: `NODE_VERSION`, `BUN_VERSION`, and `BROWSER_AGENT`.
	- Added functions to determine the runtime environment: `isBrowser`, `isNode`, and `isBun`.

- **Refactor**
	- Restructured runtime environment detection logic.
	- Moved environment-specific constants and detection functions to a centralized module.
	- Updated import statements across multiple files to use the new runtime detection module.

- **Chores**
	- Reorganized project structure for better code management.
	- Simplified environment detection mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->