### PR TITLE
fix: add from_finalize property to LiveTranscriptionEvent interface

### DIFF
--- a/src/lib/types/LiveTranscriptionEvent.ts
+++ b/src/lib/types/LiveTranscriptionEvent.ts
@@ -30,5 +30,5 @@ export interface LiveTranscriptionEvent {
     };
     model_uuid: string;
   };
-  from_finalize: boolean;
+  from_finalize?: boolean;
 }

--- a/src/lib/types/LiveTranscriptionEvent.ts
+++ b/src/lib/types/LiveTranscriptionEvent.ts
@@ -30,4 +30,5 @@ export interface LiveTranscriptionEvent {
     };
     model_uuid: string;
   };
+  from_finalize: boolean;
 }


### PR DESCRIPTION
This simply adds the `from_finalize` property to the `LiveTranscriptionEvent` type, described in [Documentation / Finalize](https://developers.deepgram.com/docs/finalize#finalize-confirmation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced live transcription event type with an optional `from_finalize` flag to provide additional event metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->