### PR TITLE
fix: keyterms to keyterm

### DIFF
--- a/examples/node-agent-live/index.js
+++ b/examples/node-agent-live/index.js
@@ -28,7 +28,7 @@ const agent = async () => {
       agent: {
         listen: {
           model: "nova-3",
-          keyterms: ["spacewalk"],
+          keyterm: ["spacewalk"],
         },
         speak: {
           model: "aura-asteria-en",

--- a/examples/node-live/index.js
+++ b/examples/node-live/index.js
@@ -21,7 +21,7 @@ const live = async () => {
     // Time in milliseconds of silence to wait for before finalizing speech
     endpointing: 300,
     // Keyterm Prompting allows you improve Keyword Recall Rate (KRR) for important keyterms or phrases up to 90%.
-    keyterms: ["BBC"],
+    keyterm: ["BBC"],
   });
 
   connection.on(LiveTranscriptionEvents.Open, () => {

--- a/examples/node-prerecorded/index.js
+++ b/examples/node-prerecorded/index.js
@@ -12,7 +12,7 @@ const transcribeUrl = async () => {
     },
     {
       model: "nova-3",
-      keyterms: ["spacewalk"],
+      keyterm: ["spacewalk"],
     }
   );
 
@@ -30,7 +30,7 @@ const transcribeFile = async () => {
   console.log("Transcribing file", file);
   const { result, error } = await deepgram.listen.prerecorded.transcribeFile(file, {
     model: "nova-3",
-    keyterms: ["spacewalk"],
+    keyterm: ["spacewalk"],
   });
 
   if (error) console.error(error);

--- a/src/lib/types/AgentLiveSchema.ts
+++ b/src/lib/types/AgentLiveSchema.ts
@@ -169,7 +169,7 @@ interface AgentLiveSchema extends Record<string, unknown> {
           /**
            * @see https://developers.deepgram.com/docs/keyterm
            */
-          keyterms?: string[];
+          keyterm?: string[];
         };
     speak: {
       /**

--- a/src/lib/types/TranscriptionSchema.ts
+++ b/src/lib/types/TranscriptionSchema.ts
@@ -97,7 +97,7 @@ interface TranscriptionSchema extends Record<string, unknown> {
   /**
    * @see https://developers.deepgram.com/docs/keyterm
    */
-  keyterms?: string[] | string;
+  keyterm?: string[] | string;
 
   /**
    * @see https://developers.deepgram.com/docs/tagging

--- a/src/packages/AgentLiveClient.ts
+++ b/src/packages/AgentLiveClient.ts
@@ -121,7 +121,7 @@ export class AgentLiveClient extends AbstractLiveClient {
    */
   public configure(options: AgentLiveSchema): void {
     // @ts-expect-error Not every consumer of the SDK is using TypeScript, this conditional exists to catch runtime errors for JS code where there is no compile-time checking.
-    if (!options.agent.listen.model.startsWith("nova-3") && options.agent.listen.keyterms?.length) {
+    if (!options.agent.listen.model.startsWith("nova-3") && options.agent.listen.keyterm?.length) {
       throw new DeepgramError("Keyterms are only supported with the Nova 3 models.");
     }
     // Converting the property names...

--- a/src/packages/ListenLiveClient.ts
+++ b/src/packages/ListenLiveClient.ts
@@ -35,10 +35,7 @@ export class ListenLiveClient extends AbstractLiveClient {
   ) {
     super(options);
 
-    if (
-      transcriptionOptions.keyterms?.length &&
-      !transcriptionOptions.model?.startsWith("nova-3")
-    ) {
+    if (transcriptionOptions.keyterm?.length && !transcriptionOptions.model?.startsWith("nova-3")) {
       throw new DeepgramError("Keyterms are only supported with the Nova 3 models.");
     }
 

--- a/src/packages/ListenRestClient.ts
+++ b/src/packages/ListenRestClient.ts
@@ -52,7 +52,7 @@ export class ListenRestClient extends AbstractRestClient {
         );
       }
 
-      if (options?.keyterms?.length && !options.model?.startsWith("nova-3")) {
+      if (options?.keyterm?.length && !options.model?.startsWith("nova-3")) {
         throw new DeepgramError("Keyterms are only supported with the Nova 3 models.");
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the audio processing keyword configuration from a plural to singular form to ensure consistency across live, recorded, and transcription functionalities.
	- Updated the handling of key term inputs to work with the new singular parameter.
	- Deprecated an older session termination method in favor of an improved alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->