### PR TITLE
fix: use role instead of type in initial messages

### DIFF
--- a/src/lib/types/AgentLiveSchema.ts
+++ b/src/lib/types/AgentLiveSchema.ts
@@ -186,7 +186,7 @@ interface AgentLiveSchema extends Record<string, unknown> {
     /**
      * LLM message history (e.g. to restore existing conversation if websocket disconnects)
      */
-    messages: { type: "user" | "assistant"; content: string }[];
+    messages: { role: "user" | "assistant"; content: string }[];
     /**
      * Whether to replay the last message, if it is an assistant message.
      */


### PR DESCRIPTION
Changed the AgentSchema.context messages array to contain 'role' instead of 'type' for 'user' or 'assistant' messages. Was receiving an error and I had no idea how to fix for a while bc this information is not present in the documentation. See issue [here](https://github.com/orgs/deepgram/discussions/1090#discussioncomment-12206601)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the consistency of message definitions for clearer differentiation between user and assistant roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->