### PR TITLE
docs: remove .live() method call from agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ import { AgentEvents } from "@deepgram/sdk";
 const deepgram = createClient(DEEPGRAM_API_KEY);
 
 // Create an agent connection
-const agent = deepgram.agent.live();
+const agent = deepgram.agent();
 
 // Set up event handlers
 agent.on(AgentEvents.Open, () => {


### PR DESCRIPTION
removes `.live` from creating an agent connection example as it's incorrect from what I can tell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README example to use the latest method for creating a voice agent connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->