### PR TITLE
fix: use type-only imports for Node.js stream module

### DIFF
--- a/src/lib/types/DeepgramSource.ts
+++ b/src/lib/types/DeepgramSource.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream";
+import type { Readable } from "stream";
 
 export type PrerecordedSource = UrlSource | Buffer | Readable;
 

--- a/src/packages/AbstractRestClient.ts
+++ b/src/packages/AbstractRestClient.ts
@@ -1,5 +1,5 @@
 import { DeepgramApiError, DeepgramError, DeepgramUnknownError } from "../lib/errors";
-import { Readable } from "stream";
+import type { Readable } from "stream";
 import { fetchWithAuth, resolveResponse } from "../lib/fetch";
 import type { Fetch, FetchOptions, RequestMethodType } from "../lib/types/Fetch";
 import { AbstractClient } from "./AbstractClient";


### PR DESCRIPTION
## Proposed changes

- Changed 'import { Readable } from "stream"' to 'import type { Readable } from "stream"' in:
  - src/packages/AbstractRestClient.ts
  - src/lib/types/DeepgramSource.ts
  - src/lib/helpers.ts
- Updated isReadStreamSource to use duck typing instead of instanceof check
- This prevents bundler errors in browser environments (React, Vite, etc)
- Maintains full type safety while removing runtime dependency on Node.js stream module

## Types of changes

What types of changes does your code introduce to the community JavaScript SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ I have manually verified this fixes the issue in the client-provided reproduction
- [ ] ~~I have added necessary documentation (if appropriate)~~

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility and performance by updating imports to use type-only imports where appropriate.
  * Enhanced reliability in browser environments by refining internal checks for stream sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->