### PR TITLE
bugfix: support keyterms with Flux models in ListenLiveClient (#449)

### DIFF
--- a/src/packages/ListenLiveClient.ts
+++ b/src/packages/ListenLiveClient.ts
@@ -1,7 +1,6 @@
 import { AbstractLiveClient } from "./AbstractLiveClient";
 import { LiveTranscriptionEvents } from "../lib/enums";
 import type { LiveSchema, LiveConfigOptions, DeepgramClientOptions } from "../lib/types";
-import { DeepgramError } from "../lib/errors";
 
 /**
  * The `ListenLiveClient` class extends the `AbstractLiveClient` class and provides functionality for setting up and managing a WebSocket connection for live transcription.


### PR DESCRIPTION
## Proposed changes

Bug: https://github.com/deepgram/deepgram-js-sdk/issues/449
Docs: https://developers.deepgram.com/docs/keyterm

Update keyterm validation to allow Flux models in addition to Nova-3. Previously, the SDK would throw an error when using keyterms with any model that didn't start with 'nova-3', but Deepgram's API supports keyterms for both Nova-3 and Flux streaming models.

I did it this way to preserve the existing validation behavior for unsupported models (e.g., nova-2) to avoid a breaking change for users. However, I do think that further work would be great to ensure that new models don't run into a similar problem. 

## Types of changes

What types of changes does your code introduce to the community JavaScript SDK?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I couldn't find existing tests that covered this area of code, so following suit from this PR https://github.com/deepgram/deepgram-js-sdk/pull/359 and just adding the bugfix in.
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyterm support broadened: keyterms are no longer restricted by model-name checks, so they can be used with additional transcription models.
* **Chores**
  * No changes to public APIs or exported interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->