### PR TITLE
docs: correct pnpm installation command and prioritize pnpm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ npm install @deepgram/sdk
 or
 
 ```bash
-pnpm install @deepgram/sdk
+pnpm add @deepgram/sdk
 ```
 
 or


### PR DESCRIPTION
I was skimming through the README and noticed a small mix-up in the installation section.

The Development Setup says to use pnpm for consistency (since the project uses Corepack), but the installation examples still list npm at the top. Also, for the pnpm example, it was using pnpm install instead of pnpm add, which is what people actually need when adding the SDK to their project.

I know it's a minor thing, but I’ve updated it to:

Put the pnpm command first so it matches the project's preferred setup.

Change the command to pnpm add @deepgram/sdk so it's technically correct.

Just wanted to make the onboarding a bit smoother for the next person. Cheers!