### PR TITLE
fix: use ws library for Bun runtime in getGlobalWebSocket

### DIFF
--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -5,13 +5,16 @@ import { toQueryString } from "../url/qs.js";
 import * as Events from "./events.js";
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== "undefined") {
-        // @ts-ignore
-        return WebSocket;
-    } else if (RUNTIME.type === "node") {
-        return NodeWebSocket as unknown as WebSocket;
-    }
-    return undefined;
+        // Bun's native WebSocket doesn't support custom headers in its constructor
+        // (the 3rd `options` argument is silently ignored), which breaks authentication.
+        // Fall through to NodeWebSocket (ws) which handles headers correctly.
+        if (RUNTIME.type !== "bun" && typeof WebSocket !== "undefined") {
+                    // @ts-ignore
+                    return WebSocket;
+        } else if (RUNTIME.type === "node" || RUNTIME.type === "bun") {
+                    return NodeWebSocket as unknown as WebSocket;
+        }
+        return undefined;
 };
 
 /**

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -4,17 +4,20 @@ import { RUNTIME } from "../runtime/index.js";
 import { toQueryString } from "../url/qs.js";
 import * as Events from "./events.js";
 
-const getGlobalWebSocket = (): WebSocket | undefined => {
-        // Bun's native WebSocket doesn't support custom headers in its constructor
-        // (the 3rd `options` argument is silently ignored), which breaks authentication.
-        // Fall through to NodeWebSocket (ws) which handles headers correctly.
-        if (RUNTIME.type !== "bun" && typeof WebSocket !== "undefined") {
-                    // @ts-ignore
-                    return WebSocket;
-        } else if (RUNTIME.type === "node" || RUNTIME.type === "bun") {
-                    return NodeWebSocket as unknown as WebSocket;
-        }
-        return undefined;
+export const getGlobalWebSocket = (): WebSocket | undefined => {
+    // Server runtimes must use the `ws` package (NodeWebSocket) because their
+    // native WebSockets (Bun, Node 21+) do not support the 3rd `options` argument for headers.
+    if (RUNTIME.type === "node" || RUNTIME.type === "bun") {
+        return NodeWebSocket as unknown as WebSocket;
+    }
+
+    // Fallback to the environment's native WebSocket (Browser, Edge, Deno, etc.)
+    if (typeof WebSocket !== "undefined") {
+        // @ts-ignore
+        return WebSocket;
+    }
+
+    return undefined;
 };
 
 /**

--- a/tests/unit/websocket-bun-runtime.test.ts
+++ b/tests/unit/websocket-bun-runtime.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Tests for WebSocket runtime selection in Bun environments.
+ *
+ * Bun's native WebSocket constructor ignores the 3rd `options` argument,
+ * which means custom headers (including `Authorization`) are silently
+ * dropped. This causes authentication failures when connecting to
+ * Deepgram's WebSocket API.
+ *
+ * The fix ensures that `getGlobalWebSocket()` returns `NodeWebSocket`
+ * (from the `ws` library) instead of Bun's native `WebSocket` when
+ * running in a Bun environment.
+ *
+ * Related issue: #466
+ */
+
+describe("WebSocket runtime selection for Bun", () => {
+      it("should skip native WebSocket when runtime is bun", () => {
+                const runtimeType = "bun";
+                const hasNativeWebSocket = true;
+
+                 const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
+
+                 expect(shouldUseNative).toBe(false);
+      });
+
+             it("should use NodeWebSocket when runtime is bun", () => {
+                       const runtimeType = "bun";
+
+                        const shouldUseNodeWebSocket = runtimeType === "node" || runtimeType === "bun";
+
+                        expect(shouldUseNodeWebSocket).toBe(true);
+             });
+
+             it("should use native WebSocket when runtime is browser", () => {
+                       const runtimeType = "browser";
+                       const hasNativeWebSocket = true;
+
+                        const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
+
+                        expect(shouldUseNative).toBe(true);
+             });
+
+             it("should use NodeWebSocket when runtime is node", () => {
+                       const runtimeType = "node";
+                       const hasNativeWebSocket = false;
+
+                        const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
+                       const shouldUseNodeWebSocket = runtimeType === "node" || runtimeType === "bun";
+
+                        expect(shouldUseNative).toBe(false);
+                       expect(shouldUseNodeWebSocket).toBe(true);
+             });
+
+             it("should return undefined when no WebSocket is available and runtime is unknown", () => {
+                       const runtimeType = "unknown";
+                       const hasNativeWebSocket = false;
+
+                        const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
+                       const shouldUseNodeWebSocket = runtimeType === "node" || runtimeType === "bun";
+
+                        expect(shouldUseNative).toBe(false);
+                       expect(shouldUseNodeWebSocket).toBe(false);
+             });
+});

--- a/tests/unit/websocket-bun-runtime.test.ts
+++ b/tests/unit/websocket-bun-runtime.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getGlobalWebSocket } from "../../src/core/websocket/ws.js";
+import { WebSocket as NodeWebSocket } from "ws";
 
 /**
  * Tests for WebSocket runtime selection in Bun environments.
@@ -10,57 +12,73 @@ import { describe, it, expect } from "vitest";
  *
  * The fix ensures that `getGlobalWebSocket()` returns `NodeWebSocket`
  * (from the `ws` library) instead of Bun's native `WebSocket` when
- * running in a Bun environment.
+ * running in a server runtime.
  *
  * Related issue: #466
  */
 
-describe("WebSocket runtime selection for Bun", () => {
-      it("should skip native WebSocket when runtime is bun", () => {
-                const runtimeType = "bun";
-                const hasNativeWebSocket = true;
+// Mock the RUNTIME object
+vi.mock("../../src/core/runtime/index.js", () => {
+    return {
+        RUNTIME: {
+            type: "browser"
+        }
+    };
+});
 
-                 const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
+import { RUNTIME } from "../../src/core/runtime/index.js";
 
-                 expect(shouldUseNative).toBe(false);
-      });
+describe("WebSocket runtime selection logic", () => {
+    let originalWebSocket: any;
 
-             it("should use NodeWebSocket when runtime is bun", () => {
-                       const runtimeType = "bun";
+    beforeEach(() => {
+        originalWebSocket = (globalThis as any).WebSocket;
+    });
 
-                        const shouldUseNodeWebSocket = runtimeType === "node" || runtimeType === "bun";
+    afterEach(() => {
+        if (originalWebSocket !== undefined) {
+            (globalThis as any).WebSocket = originalWebSocket;
+        } else {
+            delete (globalThis as any).WebSocket;
+        }
+    });
 
-                        expect(shouldUseNodeWebSocket).toBe(true);
-             });
+    it("should return NodeWebSocket when runtime is bun", () => {
+        RUNTIME.type = "bun";
+        (globalThis as any).WebSocket = class NativeBunWebSocket {};
 
-             it("should use native WebSocket when runtime is browser", () => {
-                       const runtimeType = "browser";
-                       const hasNativeWebSocket = true;
+        const wsClass = getGlobalWebSocket();
+        
+        expect(wsClass).toBe(NodeWebSocket);
+        expect(wsClass).not.toBe((globalThis as any).WebSocket);
+    });
 
-                        const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
+    it("should return NodeWebSocket when runtime is node", () => {
+        RUNTIME.type = "node";
+        (globalThis as any).WebSocket = class NativeNodeWebSocket {}; // Simulating Node 21+
 
-                        expect(shouldUseNative).toBe(true);
-             });
+        const wsClass = getGlobalWebSocket();
+        
+        expect(wsClass).toBe(NodeWebSocket);
+    });
 
-             it("should use NodeWebSocket when runtime is node", () => {
-                       const runtimeType = "node";
-                       const hasNativeWebSocket = false;
+    it("should return native WebSocket when runtime is browser", () => {
+        RUNTIME.type = "browser";
+        const MockNativeWebSocket = class {};
+        (globalThis as any).WebSocket = MockNativeWebSocket;
 
-                        const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
-                       const shouldUseNodeWebSocket = runtimeType === "node" || runtimeType === "bun";
+        const wsClass = getGlobalWebSocket();
+        
+        expect(wsClass).toBe(MockNativeWebSocket);
+        expect(wsClass).not.toBe(NodeWebSocket);
+    });
 
-                        expect(shouldUseNative).toBe(false);
-                       expect(shouldUseNodeWebSocket).toBe(true);
-             });
+    it("should return undefined when no WebSocket is available and runtime is unknown", () => {
+        RUNTIME.type = "unknown";
+        delete (globalThis as any).WebSocket;
 
-             it("should return undefined when no WebSocket is available and runtime is unknown", () => {
-                       const runtimeType = "unknown";
-                       const hasNativeWebSocket = false;
-
-                        const shouldUseNative = runtimeType !== "bun" && hasNativeWebSocket;
-                       const shouldUseNodeWebSocket = runtimeType === "node" || runtimeType === "bun";
-
-                        expect(shouldUseNative).toBe(false);
-                       expect(shouldUseNodeWebSocket).toBe(false);
-             });
+        const wsClass = getGlobalWebSocket();
+        
+        expect(wsClass).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #466

Bun's native `WebSocket` constructor ignores the 3rd `options` argument (including `headers`), which silently drops the `Authorization` header when connecting to Deepgram's WebSocket API. This causes the connection to fail with `readyState: 3` (CLOSED) immediately.

## Changes

### `src/core/websocket/ws.ts`
- Modified `getGlobalWebSocket()` to skip Bun's native `WebSocket` and fall back to `NodeWebSocket` (`ws` library) when `RUNTIME.type === "bun"`
- The `ws` library correctly supports custom headers in its constructor

### `tests/unit/websocket-bun-runtime.test.ts`
- Added unit tests verifying the runtime selection logic for Bun, Node, browser, and unknown environments

## Root Cause

```js
// Before: Bun hits the first condition because it has a native WebSocket global
if (typeof WebSocket !== "undefined") {
    return WebSocket; // Bun's native - ignores headers
} else if (RUNTIME.type === "node") {
    return NodeWebSocket; // Never reached for Bun
}
```

```js
// After: Bun is excluded from native and included in NodeWebSocket fallback
if (RUNTIME.type !== "bun" && typeof WebSocket !== "undefined") {
    return WebSocket;
} else if (RUNTIME.type === "node" || RUNTIME.type === "bun") {
    return NodeWebSocket; // ws library - supports headers
}
```

## Testing

- Unit tests added for runtime selection logic
- Manually verified with Bun v1.3.10 that `ws` library establishes successful WebSocket connections with Deepgram