### PR TITLE
fix(listen): warn when keywords is used with nova-3 model

### DIFF
--- a/src/CustomClient.ts
+++ b/src/CustomClient.ts
@@ -629,9 +629,23 @@ class WrappedAgentV1Socket extends AgentV1Socket {
  * consistent behavior across Fern regenerations and allows us to customize
  * connection setup, authentication, and header handling.
  */
+const NOVA3_MODELS = ["nova-3", "nova-3-general", "nova-3-medical"] as const;
+
 class WrappedListenV1Client extends ListenV1Client {
     public async connect(args: Omit<ListenV1Client.ConnectArgs, "Authorization"> & { Authorization?: string }): Promise<ListenV1Socket> {
         const { headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+
+        // Warn when 'keywords' is used with nova-3 — the API rejects this combination.
+        // 'keywords' is not supported on nova-3; use 'keyterm' instead.
+        const model = (args as Record<string, unknown>).model as string | undefined;
+        const keywords = (args as Record<string, unknown>).keywords;
+        if (keywords != null && model != null && NOVA3_MODELS.some((m) => model === m || model.startsWith(m))) {
+            console.warn(
+                "[Deepgram] The 'keywords' parameter is not supported with nova-3 models and will cause " +
+                "the WebSocket connection to be rejected (HTTP 400). Use 'keyterm' instead. " +
+                "See: https://developers.deepgram.com/docs/keyterm"
+            );
+        }
 
         const socket = await createWebSocketConnection({
             options: this._options,


### PR DESCRIPTION
Fixes #474

Adds a runtime `console.warn()` in `WrappedListenV1Client.connect()` when the caller passes both `keywords` and a nova-3 model (`nova-3`, `nova-3-general`, `nova-3-medical`). The Deepgram API silently rejects this combination with an HTTP 400, making it very hard to diagnose.

**Before:** The WebSocket upgrade fails with a bare HTTP 400 — no feedback to the developer.

**After:** A clear warning is printed before the connection attempt:
```
[Deepgram] The 'keywords' parameter is not supported with nova-3 models and will cause
the WebSocket connection to be rejected (HTTP 400). Use 'keyterm' instead.
See: https://developers.deepgram.com/docs/keyterm
```

**Why `CustomClient.ts`:** This file is not auto-generated by Fern and will survive SDK regenerations. The check is placed before the WebSocket is created so developers see the warning immediately.

No breaking changes — this is a warning only, existing behavior is unchanged.