### PR TITLE
feat: add pluggable transport interface for sagemaker support

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,6 +4,7 @@ examples
 # Custom wrapper
 src/CustomClient.ts
 src/index.ts
+src/transport.ts
 
 # Custom Scripts
 scripts/fix-wire-test-imports.js
@@ -25,6 +26,7 @@ tests/unit/custom-client.test.ts
 tests/unit/error-handling.test.ts
 tests/unit/multiple-keyterms.test.ts
 tests/unit/nodejs-version-compatibility.test.ts
+tests/unit/transport-factory.test.ts
 tests/unit/websocket-reconnection.test.ts
 tests/unit/websocket-wrappers.test.ts
 tests/wire/websocket

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ How to identify:
 Current permanently frozen files:
 - `src/CustomClient.ts` — entirely custom wrapper with WebSocket management, auth providers, and session ID handling; no Fern equivalent
 - `src/index.ts` — curated re-export file with custom namespace handling
+- `src/transport.ts` — hand-maintained pluggable transport interface for SageMaker and other custom streaming transports
 - `scripts/fix-wire-test-imports.js`, `scripts/revert-wire-test-imports.js` — post-generation import fixup scripts
 - `scripts/proxy-server.js` — development proxy server
 - `scripts/validate-esm-build.mjs` — ESM build validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ How to identify:
 - The file lives **outside `src/api/`** in a hand-maintained location (e.g., `.claude/`, `docs/`, `scripts/`)
 
 Current permanently frozen files:
-- `src/CustomClient.ts` — entirely custom wrapper with WebSocket management, auth providers, and session ID handling; no Fern equivalent
+- `src/CustomClient.ts` — entirely custom wrapper with WebSocket management, auth providers, session ID handling, `transportFactory` plumbing, and the `reconnect` flag (auto-disabled when a custom transport is in use); no Fern equivalent
 - `src/index.ts` — curated re-export file with custom namespace handling
 - `src/transport.ts` — hand-maintained pluggable transport interface for SageMaker and other custom streaming transports
 - `scripts/fix-wire-test-imports.js`, `scripts/revert-wire-test-imports.js` — post-generation import fixup scripts

--- a/src/CustomClient.ts
+++ b/src/CustomClient.ts
@@ -17,8 +17,15 @@ import { V1Socket as SpeakV1Socket } from "./api/resources/speak/resources/v1/cl
 import { mergeHeaders } from "./core/headers.js";
 import { fromJson } from "./core/json.js";
 import * as core from "./core/index.js";
+import * as websocketEvents from "./core/websocket/events.js";
 import * as environments from "./environments.js";
 import { RUNTIME } from "./core/runtime/index.js";
+import type {
+    DeepgramTransport,
+    DeepgramTransportFactory,
+    DeepgramTransportMessage,
+    DeepgramTransportRequest,
+} from "./transport.js";
 
 // Default WebSocket connection timeout in milliseconds
 const DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
@@ -28,6 +35,7 @@ const DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
 const WEBSOCKET_OPTION_KEYS = new Set([
     "Authorization",
     "headers",
+    "protocols",
     "debug",
     "reconnectAttempts",
     "connectionTimeoutInSeconds",
@@ -72,7 +80,7 @@ function generateUUID(): string {
     if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
         return crypto.randomUUID();
     }
-
+    
     // Fallback for Node.js: use the crypto module
     if (RUNTIME.type === "node") {
         try {
@@ -83,7 +91,7 @@ function generateUUID(): string {
             // Fallback if crypto module is not available
         }
     }
-
+    
     // Final fallback: manual UUID generation (RFC4122 version 4)
     // This should work everywhere but is less secure than crypto.randomUUID()
     return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -107,15 +115,11 @@ class ApiKeyAuthProviderWrapper implements core.AuthProvider {
     public async getAuthRequest(arg?: { endpointMetadata?: core.EndpointMetadata }): Promise<core.AuthRequest> {
         const authRequest = await this.originalProvider.getAuthRequest(arg);
         const authHeader = authRequest.headers?.Authorization || authRequest.headers?.authorization;
-
+        
         // If the header doesn't already have a scheme prefix, add "Token " prefix for API keys
         if (authHeader && typeof authHeader === "string") {
             // Only add prefix if it doesn't already have Bearer or Token prefix
-            if (
-                !authHeader.startsWith("Bearer ") &&
-                !authHeader.startsWith("Token ") &&
-                !authHeader.startsWith("token ")
-            ) {
+            if (!authHeader.startsWith("Bearer ") && !authHeader.startsWith("Token ") && !authHeader.startsWith("token ")) {
                 return {
                     headers: {
                         ...authRequest.headers,
@@ -124,7 +128,7 @@ class ApiKeyAuthProviderWrapper implements core.AuthProvider {
                 };
             }
         }
-
+        
         return authRequest;
     }
 }
@@ -202,25 +206,30 @@ export interface SpeakClientWithWebSockets extends SpeakClient {
  * Custom wrapper around DeepgramClient that ensures the custom websocket implementation
  * from ws.ts is always used, even if the auto-generated code changes.
  */
+export interface CustomDeepgramClientOptions extends DeepgramClient.Options {
+    accessToken?: core.Supplier<string | undefined>;
+    transportFactory?: DeepgramTransportFactory;
+}
+
 export class CustomDeepgramClient extends DeepgramClient {
     private _customAgent: AgentClientWithWebSockets | undefined;
     private _customListen: ListenClientWithWebSockets | undefined;
     private _customSpeak: SpeakClientWithWebSockets | undefined;
     private readonly _sessionId: string;
 
-    constructor(options: DeepgramClient.Options & { accessToken?: core.Supplier<string | undefined> } = {}) {
+    constructor(options: CustomDeepgramClientOptions = {}) {
         // Generate a UUID for the session ID
         const sessionId = generateUUID();
-
+        
         // Add the session ID to headers so it's included in all REST requests
-        const optionsWithSessionId: DeepgramClient.Options = {
+        const optionsWithSessionId: CustomDeepgramClientOptions = {
             ...options,
             headers: {
                 ...options.headers,
                 "x-deepgram-session-id": sessionId,
             },
         };
-
+        
         super(optionsWithSessionId);
         this._sessionId = sessionId;
 
@@ -233,7 +242,7 @@ export class CustomDeepgramClient extends DeepgramClient {
         if (options.accessToken != null) {
             (this._options as any).authProvider = new AccessTokenAuthProviderWrapper(
                 this._options.authProvider,
-                options.accessToken,
+                options.accessToken
             );
         }
     }
@@ -365,45 +374,481 @@ function buildQueryParams(args: Record<string, unknown>): Record<string, unknown
     return result;
 }
 
+function normalizeProtocols(protocols?: string | string[]): string[] {
+    if (protocols == null) {
+        return [];
+    }
+
+    return Array.isArray(protocols) ? protocols : [protocols];
+}
+
+function stringifyHeaders(headers: Record<string, unknown>): Record<string, string> {
+    const result: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(headers)) {
+        result[key] = String(value);
+    }
+
+    return result;
+}
+
+function buildWebSocketUrl(url: string, queryParams: Record<string, unknown>): string {
+    const queryString = core.url.toQueryString(queryParams, { arrayFormat: "repeat" });
+    return queryString ? `${url}?${queryString}` : url;
+}
+
+function getTransportFactory(options: DeepgramClient.Options): DeepgramTransportFactory | undefined {
+    return (options as CustomDeepgramClientOptions).transportFactory;
+}
+
+class TransportWebSocketAdapter {
+    private _listeners: ReconnectingWebSocket.ListenersMap = {
+        error: [],
+        message: [],
+        open: [],
+        close: [],
+    };
+    private _retryCount = -1;
+    private _shouldReconnect = true;
+    private _connectLock = false;
+    private _binaryType: BinaryType = "blob";
+    private _closeCalled = false;
+    private _messageQueue: DeepgramTransportMessage[] = [];
+    private _connectTimeout: ReturnType<typeof setTimeout> | undefined;
+    private _transport: DeepgramTransport | undefined;
+    private _readyState: ReconnectingWebSocket.ReadyState;
+    private _ws:
+        | {
+              OPEN: typeof ReconnectingWebSocket.OPEN;
+              readyState: ReconnectingWebSocket.ReadyState;
+              ping?: (data?: string | ArrayBuffer | Blob | ArrayBufferView) => void;
+          }
+        | undefined;
+
+    private readonly _factory: DeepgramTransportFactory;
+    private readonly _request: DeepgramTransportRequest;
+
+    constructor(args: { factory: DeepgramTransportFactory; request: DeepgramTransportRequest; startClosed?: boolean }) {
+        this._factory = args.factory;
+        this._request = args.request;
+        this._readyState = args.startClosed ? ReconnectingWebSocket.ReadyState.CLOSED : ReconnectingWebSocket.ReadyState.CONNECTING;
+
+        if (this._request.abortSignal) {
+            this._request.abortSignal.addEventListener("abort", this._handleAbort, { once: true });
+        }
+
+        if (!args.startClosed) {
+            void this._connect();
+        }
+    }
+
+    public static readonly CONNECTING = ReconnectingWebSocket.CONNECTING;
+    public static readonly OPEN = ReconnectingWebSocket.OPEN;
+    public static readonly CLOSING = ReconnectingWebSocket.CLOSING;
+    public static readonly CLOSED = ReconnectingWebSocket.CLOSED;
+
+    public readonly CONNECTING: typeof ReconnectingWebSocket.CONNECTING = ReconnectingWebSocket.CONNECTING;
+    public readonly OPEN: typeof ReconnectingWebSocket.OPEN = ReconnectingWebSocket.OPEN;
+    public readonly CLOSING: typeof ReconnectingWebSocket.CLOSING = ReconnectingWebSocket.CLOSING;
+    public readonly CLOSED: typeof ReconnectingWebSocket.CLOSED = ReconnectingWebSocket.CLOSED;
+
+    public onclose: ((event: websocketEvents.CloseEvent) => void) | null = null;
+    public onerror: ((event: websocketEvents.ErrorEvent) => void) | null = null;
+    public onmessage: ((event: MessageEvent) => void) | null = null;
+    public onopen: ((event: websocketEvents.Event) => void) | null = null;
+
+    get binaryType(): BinaryType {
+        return this._binaryType;
+    }
+
+    set binaryType(value: BinaryType) {
+        this._binaryType = value;
+    }
+
+    get retryCount(): number {
+        return Math.max(this._retryCount, 0);
+    }
+
+    get bufferedAmount(): number {
+        return this._messageQueue.reduce((acc, message) => {
+            if (typeof message === "string") {
+                return acc + message.length;
+            }
+            if (message instanceof Blob) {
+                return acc + message.size;
+            }
+            return acc + message.byteLength;
+        }, 0);
+    }
+
+    get extensions(): string {
+        return "";
+    }
+
+    get protocol(): string {
+        return this._request.protocols[0] ?? "";
+    }
+
+    get readyState(): ReconnectingWebSocket.ReadyState {
+        return this._readyState;
+    }
+
+    get url(): string {
+        return this._request.url;
+    }
+
+    public close(code = 1000, reason?: string): void {
+        this._closeCalled = true;
+        this._shouldReconnect = false;
+        this._clearConnectTimeout();
+        this._readyState = ReconnectingWebSocket.ReadyState.CLOSING;
+
+        const transport = this._transport;
+        this._transport = undefined;
+        this._setTransportHandle(undefined);
+
+        if (!transport) {
+            this._readyState = ReconnectingWebSocket.ReadyState.CLOSED;
+            return;
+        }
+
+        void transport.close(code, reason);
+        this._readyState = ReconnectingWebSocket.ReadyState.CLOSED;
+    }
+
+    public reconnect(code?: number, reason?: string): void {
+        this._shouldReconnect = true;
+        this._closeCalled = false;
+        this._retryCount = -1;
+        this._readyState = ReconnectingWebSocket.ReadyState.CONNECTING;
+
+        const transport = this._transport;
+        this._transport = undefined;
+        this._setTransportHandle(undefined);
+
+        if (transport) {
+            void transport.close(code, reason);
+        }
+
+        void this._connect();
+    }
+
+    public send(data: DeepgramTransportMessage): void {
+        if (this._transport?.isOpen()) {
+            void this._transport.send(data);
+            return;
+        }
+
+        this._messageQueue.push(data);
+    }
+
+    public addEventListener<T extends keyof websocketEvents.WebSocketEventListenerMap>(
+        type: T,
+        listener: websocketEvents.WebSocketEventListenerMap[T],
+    ): void {
+        if (this._listeners[type]) {
+            (this._listeners[type] as Array<websocketEvents.WebSocketEventListenerMap[T]>).push(listener);
+        }
+    }
+
+    public dispatchEvent(event: websocketEvents.Event): boolean {
+        const listeners = this._listeners[event.type as keyof websocketEvents.WebSocketEventListenerMap];
+
+        if (listeners) {
+            for (const listener of listeners) {
+                this._callEventListener(event as never, listener as never);
+            }
+        }
+
+        return true;
+    }
+
+    public removeEventListener<T extends keyof websocketEvents.WebSocketEventListenerMap>(
+        type: T,
+        listener: websocketEvents.WebSocketEventListenerMap[T],
+    ): void {
+        if (this._listeners[type]) {
+            this._listeners[type] = this._listeners[type].filter((registered) => registered !== listener) as never;
+        }
+    }
+
+    private _debug(...args: unknown[]): void {
+        if (this._request.debug) {
+            // biome-ignore lint/suspicious/noConsole: transport debug logging mirrors websocket debug logging
+            console.log.apply(console, ["DG-TRANSPORT>", ...args]);
+        }
+    }
+
+    private _handleAbort = () => {
+        if (this._closeCalled) {
+            return;
+        }
+
+        this._debug("abort signal fired");
+        this._closeCalled = true;
+        this._shouldReconnect = false;
+        this._clearConnectTimeout();
+
+        const transport = this._transport;
+        this._transport = undefined;
+        this._setTransportHandle(undefined);
+
+        if (transport) {
+            void transport.close(1000, "aborted");
+        }
+
+        this._readyState = ReconnectingWebSocket.ReadyState.CLOSED;
+        this._emitClose(1000, "aborted");
+    };
+
+    private async _connect(): Promise<void> {
+        if (this._connectLock || !this._shouldReconnect || this._request.abortSignal?.aborted) {
+            return;
+        }
+
+        if (this._retryCount >= this._request.reconnectAttempts) {
+            this._debug("max retries reached", this._retryCount, ">=", this._request.reconnectAttempts);
+            return;
+        }
+
+        this._connectLock = true;
+        this._retryCount++;
+        this._readyState = ReconnectingWebSocket.ReadyState.CONNECTING;
+        this._clearConnectTimeout();
+
+        try {
+            const transport = await this._factory(this._request.url, this._request.headers, this._request);
+
+            if (this._closeCalled || this._request.abortSignal?.aborted) {
+                this._connectLock = false;
+                await transport.close(1000, "aborted");
+                return;
+            }
+
+            this._transport = transport;
+            this._setTransportHandle(transport);
+            this._bindTransport(transport);
+            this._armConnectTimeout();
+            this._connectLock = false;
+
+            if (transport.isOpen()) {
+                this._handleOpen(transport);
+            }
+        } catch (error) {
+            this._connectLock = false;
+            this._handleError(error instanceof Error ? error : new Error(String(error)));
+        }
+    }
+
+    private _bindTransport(transport: DeepgramTransport): void {
+        transport.onOpen(() => {
+            if (this._transport !== transport) {
+                return;
+            }
+
+            this._handleOpen(transport);
+        });
+
+        transport.onMessage((message) => {
+            if (this._transport !== transport) {
+                return;
+            }
+
+            this._handleMessage(message);
+        });
+
+        transport.onError((error) => {
+            if (this._transport !== transport) {
+                return;
+            }
+
+            this._handleError(error);
+        });
+
+        transport.onClose((event) => {
+            if (this._transport !== transport) {
+                return;
+            }
+
+            this._handleClose(event.code ?? 1000, event.reason ?? "");
+        });
+    }
+
+    private _armConnectTimeout(): void {
+        const timeoutMs =
+            this._request.connectionTimeoutInSeconds != null
+                ? this._request.connectionTimeoutInSeconds * 1000
+                : DEFAULT_CONNECTION_TIMEOUT_MS;
+
+        this._connectTimeout = setTimeout(() => {
+            this._handleError(new Error("TIMEOUT"));
+        }, timeoutMs);
+    }
+
+    private _clearConnectTimeout(): void {
+        if (this._connectTimeout != null) {
+            clearTimeout(this._connectTimeout);
+            this._connectTimeout = undefined;
+        }
+    }
+
+    private _handleOpen(transport: DeepgramTransport): void {
+        if (this._transport !== transport || this._readyState === ReconnectingWebSocket.ReadyState.OPEN) {
+            return;
+        }
+
+        this._debug("open event");
+        this._clearConnectTimeout();
+        this._readyState = ReconnectingWebSocket.ReadyState.OPEN;
+
+        const queued = [...this._messageQueue];
+        this._messageQueue = [];
+        for (const message of queued) {
+            void transport.send(message);
+        }
+
+        const event = new websocketEvents.Event("open", this);
+        if (this.onopen) {
+            this.onopen(event);
+        }
+        this._listeners.open.forEach((listener) => this._callEventListener(event, listener));
+    }
+
+    private _handleMessage(message: DeepgramTransportMessage): void {
+        const event = { type: "message", data: message, target: this } as unknown as MessageEvent;
+
+        if (this.onmessage) {
+            this.onmessage(event);
+        }
+        this._listeners.message.forEach((listener) => this._callEventListener(event, listener));
+    }
+
+    private _handleError(error: Error): void {
+        this._debug("error event", error.message);
+        this._clearConnectTimeout();
+        this._readyState = ReconnectingWebSocket.ReadyState.CLOSED;
+
+        const event = new websocketEvents.ErrorEvent(error, this);
+        if (this.onerror) {
+            this.onerror(event);
+        }
+        this._listeners.error.forEach((listener) => this._callEventListener(event, listener));
+
+        const transport = this._transport;
+        this._transport = undefined;
+        this._setTransportHandle(undefined);
+
+        if (transport) {
+            void transport.close(1011, error.message);
+        }
+
+        if (this._shouldReconnect && !this._closeCalled) {
+            void this._connect();
+        }
+    }
+
+    private _handleClose(code: number, reason: string): void {
+        this._debug("close event", code, reason);
+        this._clearConnectTimeout();
+        this._transport = undefined;
+        this._readyState = ReconnectingWebSocket.ReadyState.CLOSED;
+        this._setTransportHandle(undefined);
+
+        if (code === 1000) {
+            this._shouldReconnect = false;
+        }
+
+        this._emitClose(code, reason);
+
+        if (this._shouldReconnect && !this._closeCalled) {
+            void this._connect();
+        }
+    }
+
+    private _emitClose(code: number, reason: string): void {
+        const event = new websocketEvents.CloseEvent(code, reason, this);
+
+        if (this.onclose) {
+            this.onclose(event);
+        }
+        this._listeners.close.forEach((listener) => this._callEventListener(event, listener));
+    }
+
+    private _setTransportHandle(transport: DeepgramTransport | undefined): void {
+        if (!transport) {
+            this._ws = undefined;
+            return;
+        }
+
+        this._ws = {
+            OPEN: this.OPEN,
+            get readyState() {
+                return transport.isOpen()
+                    ? ReconnectingWebSocket.ReadyState.OPEN
+                    : ReconnectingWebSocket.ReadyState.CLOSED;
+            },
+            ping: transport.ping
+                ? (data?: string | ArrayBuffer | Blob | ArrayBufferView) => {
+                      void transport.ping?.(data);
+                  }
+                : undefined,
+        };
+    }
+
+    private _callEventListener<T extends keyof websocketEvents.WebSocketEventListenerMap>(
+        event: websocketEvents.WebSocketEventMap[T],
+        listener: websocketEvents.WebSocketEventListenerMap[T],
+    ): void {
+        if (typeof listener === "object" && listener && "handleEvent" in listener) {
+            (listener as { handleEvent: (event: websocketEvents.WebSocketEventMap[T]) => void }).handleEvent(event);
+        } else {
+            (listener as (event: websocketEvents.WebSocketEventMap[T]) => void)(event);
+        }
+    }
+}
+
 /**
  * Helper function to get WebSocket class and handle headers/protocols based on runtime.
  * In Node.js, use the 'ws' library which supports headers.
  * In browser, use Sec-WebSocket-Protocol for authentication since headers aren't supported.
  */
-function getWebSocketOptions(headers: Record<string, unknown>): {
-    WebSocket?: any;
-    headers?: Record<string, unknown>;
+function getWebSocketOptions(headers: Record<string, unknown>, requestedProtocols: string[]): { 
+    WebSocket?: any; 
+    headers?: Record<string, unknown>; 
     protocols?: string[];
 } {
     const options: { WebSocket?: any; headers?: Record<string, unknown>; protocols?: string[] } = {};
-
+    
     // Check if we're in a browser environment (browser or web-worker)
     const isBrowser = RUNTIME.type === "browser" || RUNTIME.type === "web-worker";
-
+    
     // Extract session ID header
     const sessionIdHeader = headers["x-deepgram-session-id"] || headers["X-Deepgram-Session-Id"];
-
+    
     // In Node.js, ensure we use the 'ws' library which supports headers
     if (RUNTIME.type === "node" && NodeWebSocket) {
         options.WebSocket = NodeWebSocket;
         options.headers = headers;
+        if (requestedProtocols.length > 0) {
+            options.protocols = requestedProtocols;
+        }
     } else if (isBrowser) {
         // In browser, native WebSocket doesn't support custom headers
         // Extract Authorization header and use Sec-WebSocket-Protocol instead
         const authHeader = headers.Authorization || headers.authorization;
         const browserHeaders: Record<string, unknown> = { ...headers };
-
+        
         // Remove Authorization and session ID from headers since they won't work in browser
         delete browserHeaders.Authorization;
         delete browserHeaders.authorization;
         delete browserHeaders["x-deepgram-session-id"];
         delete browserHeaders["X-Deepgram-Session-Id"];
-
+        
         options.headers = browserHeaders;
-
+        
         // Build protocols array for browser WebSocket
-        const protocols: string[] = [];
-
+        const protocols = [...requestedProtocols];
+        
         // If we have an Authorization header, extract the token and format as protocols
         // Deepgram expects:
         // - For API keys: Sec-WebSocket-Protocol: token,API_KEY_GOES_HERE
@@ -423,20 +868,23 @@ function getWebSocketOptions(headers: Record<string, unknown>): {
                 protocols.push(authHeader);
             }
         }
-
+        
         // Add session ID as a protocol for browser WebSocket
         if (sessionIdHeader && typeof sessionIdHeader === "string") {
             protocols.push("x-deepgram-session-id", sessionIdHeader);
         }
-
+        
         if (protocols.length > 0) {
             options.protocols = protocols;
         }
     } else {
         // Fallback for other environments
         options.headers = headers;
+        if (requestedProtocols.length > 0) {
+            options.protocols = requestedProtocols;
+        }
     }
-
+    
     return options;
 }
 
@@ -444,10 +892,7 @@ function getWebSocketOptions(headers: Record<string, unknown>): {
  * Helper function to setup binary-aware message handling for WebSocket sockets.
  * Handles both text (JSON) and binary messages correctly.
  */
-function setupBinaryHandling(
-    socket: ReconnectingWebSocket,
-    eventHandlers: { message?: (data: any) => void },
-): (event: MessageEvent) => void {
+function setupBinaryHandling(socket: ReconnectingWebSocket, eventHandlers: { message?: (data: any) => void }): (event: MessageEvent) => void {
     const binaryAwareHandler = (event: MessageEvent) => {
         // Handle both text (JSON) and binary messages
         if (typeof event.data === "string") {
@@ -472,10 +917,10 @@ function setupBinaryHandling(
             socket.removeEventListener("message", listener);
         });
     }
-
+    
     // Add our binary-aware handler
     socket.addEventListener("message", binaryAwareHandler);
-
+    
     return binaryAwareHandler;
 }
 
@@ -484,15 +929,12 @@ function setupBinaryHandling(
  * This removes all event listeners that were registered by the auto-generated
  * Socket class constructor, preventing duplicate event firing when connect() is called.
  */
-function preventDuplicateEventListeners(
-    socket: ReconnectingWebSocket,
-    handlers: {
-        handleOpen?: () => void;
-        handleMessage?: (event: any) => void;
-        handleClose?: (event: any) => void;
-        handleError?: (event: any) => void;
-    },
-) {
+function preventDuplicateEventListeners(socket: ReconnectingWebSocket, handlers: {
+    handleOpen?: () => void;
+    handleMessage?: (event: any) => void;
+    handleClose?: (event: any) => void;
+    handleError?: (event: any) => void;
+}) {
     // Remove the handlers that were added by the auto-generated constructor
     if (handlers.handleOpen) {
         socket.removeEventListener("open", handlers.handleOpen);
@@ -530,6 +972,8 @@ async function createWebSocketConnection({
     urlPath,
     environmentKey,
     queryParams,
+    protocols,
+    service,
     headers,
     debug,
     reconnectAttempts,
@@ -540,6 +984,8 @@ async function createWebSocketConnection({
     urlPath: string;
     environmentKey: "agent" | "production";
     queryParams: Record<string, unknown>;
+    protocols?: string | string[];
+    service: DeepgramTransportRequest["service"];
     headers?: Record<string, unknown>;
     debug?: boolean;
     reconnectAttempts?: number;
@@ -553,22 +999,54 @@ async function createWebSocketConnection({
     const authRequest = await (options as any).authProvider?.getAuthRequest();
 
     // Merge headers from options (which includes session ID), auth headers, and request headers
-    const mergedHeaders = mergeHeaders(options.headers ?? {}, authRequest?.headers ?? {}, headers);
+    const mergedHeaders = mergeHeaders(
+        options.headers ?? {},
+        authRequest?.headers ?? {},
+        headers,
+    );
 
     // Resolve any Suppliers in headers to actual values
     const _headers = await resolveHeaders(mergedHeaders);
-
-    // Get WebSocket options with proper header handling
-    const wsOptions = getWebSocketOptions(_headers);
+    const normalizedProtocols = normalizeProtocols(protocols);
 
     // Get the appropriate base URL for the environment
-    const baseUrl =
-        (await core.Supplier.get(options.baseUrl)) ??
-        ((await core.Supplier.get(options.environment)) ?? environments.DeepgramEnvironment.Production)[environmentKey];
+    const baseUrl = (await core.Supplier.get(options.baseUrl)) ??
+        (
+            (await core.Supplier.get(options.environment)) ??
+            environments.DeepgramEnvironment.Production
+        )[environmentKey];
+
+    const url = core.url.join(baseUrl, urlPath);
+    const fullUrl = buildWebSocketUrl(url, queryParams);
+    const transportFactory = getTransportFactory(options);
+
+    if (transportFactory) {
+        const request: DeepgramTransportRequest = {
+            url: fullUrl,
+            headers: stringifyHeaders(_headers),
+            protocols: normalizedProtocols,
+            path: urlPath,
+            service,
+            queryParams,
+            debug: debug ?? false,
+            reconnectAttempts: reconnectAttempts ?? 30,
+            connectionTimeoutInSeconds,
+            abortSignal,
+        };
+
+        return new TransportWebSocketAdapter({
+            factory: transportFactory,
+            request,
+            startClosed: true,
+        }) as unknown as ReconnectingWebSocket;
+    }
+
+    // Get WebSocket options with proper header handling
+    const wsOptions = getWebSocketOptions(_headers, normalizedProtocols);
 
     // Create and return the ReconnectingWebSocket
     return new ReconnectingWebSocket({
-        url: core.url.join(baseUrl, urlPath),
+        url,
         protocols: wsOptions.protocols ?? [],
         queryParameters: queryParams,
         headers: wsOptions.headers,
@@ -577,8 +1055,7 @@ async function createWebSocketConnection({
             debug: debug ?? false,
             maxRetries: reconnectAttempts ?? 30,
             startClosed: true,
-            connectionTimeout:
-                connectionTimeoutInSeconds != null ? connectionTimeoutInSeconds * 1000 : DEFAULT_CONNECTION_TIMEOUT_MS,
+            connectionTimeout: connectionTimeoutInSeconds != null ? connectionTimeoutInSeconds * 1000 : DEFAULT_CONNECTION_TIMEOUT_MS,
         },
         abortSignal,
     });
@@ -593,16 +1070,16 @@ async function createWebSocketConnection({
  * connection setup, authentication, and header handling.
  */
 class WrappedAgentV1Client extends AgentV1Client {
-    public async connect(
-        args: Omit<AgentV1Client.ConnectArgs, "Authorization"> & { Authorization?: string } = {},
-    ): Promise<AgentV1Socket> {
-        const { headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+    public async connect(args: Omit<AgentV1Client.ConnectArgs, "Authorization"> & { Authorization?: string } = {}): Promise<AgentV1Socket> {
+        const { headers, protocols, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
 
         const socket = await createWebSocketConnection({
             options: this._options,
             urlPath: "/v1/agent/converse",
-            environmentKey: "agent",
+            environmentKey: 'agent',
             queryParams: buildQueryParams(args as Record<string, unknown>),
+            protocols,
+            service: "agent.v1",
             headers,
             debug,
             reconnectAttempts,
@@ -626,9 +1103,7 @@ class WrappedAgentV1Client extends AgentV1Client {
      * socket.connect(); // Actually initiates the connection
      * ```
      */
-    public async createConnection(
-        args: Omit<AgentV1Client.ConnectArgs, "Authorization"> & { Authorization?: string } = {},
-    ): Promise<AgentV1Socket> {
+    public async createConnection(args: Omit<AgentV1Client.ConnectArgs, "Authorization"> & { Authorization?: string } = {}): Promise<AgentV1Socket> {
         return this.connect(args);
     }
 }
@@ -660,7 +1135,7 @@ class WrappedAgentV1Socket extends AgentV1Socket {
             handleOpen: socketAny.handleOpen,
             handleMessage: socketAny.handleMessage,
             handleClose: socketAny.handleClose,
-            handleError: socketAny.handleError,
+            handleError: socketAny.handleError
         });
 
         resetSocketConnectionState(this.socket);
@@ -680,16 +1155,16 @@ class WrappedAgentV1Socket extends AgentV1Socket {
  * connection setup, authentication, and header handling.
  */
 class WrappedListenV1Client extends ListenV1Client {
-    public async connect(
-        args: Omit<ListenV1Client.ConnectArgs, "Authorization"> & { Authorization?: string },
-    ): Promise<ListenV1Socket> {
-        const { headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+    public async connect(args: Omit<ListenV1Client.ConnectArgs, "Authorization"> & { Authorization?: string }): Promise<ListenV1Socket> {
+        const { headers, protocols, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
 
         const socket = await createWebSocketConnection({
             options: this._options,
             urlPath: "/v1/listen",
-            environmentKey: "production",
+            environmentKey: 'production',
             queryParams: buildQueryParams(args as Record<string, unknown>),
+            protocols,
+            service: "listen.v1",
             headers,
             debug,
             reconnectAttempts,
@@ -713,9 +1188,7 @@ class WrappedListenV1Client extends ListenV1Client {
      * socket.connect(); // Actually initiates the connection
      * ```
      */
-    public async createConnection(
-        args: Omit<ListenV1Client.ConnectArgs, "Authorization"> & { Authorization?: string },
-    ): Promise<ListenV1Socket> {
+    public async createConnection(args: Omit<ListenV1Client.ConnectArgs, "Authorization"> & { Authorization?: string }): Promise<ListenV1Socket> {
         return this.connect(args);
     }
 }
@@ -747,7 +1220,7 @@ class WrappedListenV1Socket extends ListenV1Socket {
             handleOpen: socketAny.handleOpen,
             handleMessage: socketAny.handleMessage,
             handleClose: socketAny.handleClose,
-            handleError: socketAny.handleError,
+            handleError: socketAny.handleError
         });
 
         resetSocketConnectionState(this.socket);
@@ -770,15 +1243,17 @@ class WrappedListenV2Client extends ListenV2Client {
         args: Omit<ListenV2Client.ConnectArgs, "Authorization" | "keyterm"> & {
             Authorization?: string;
             keyterm?: string | string[];
-        },
+        }
     ): Promise<ListenV2Socket> {
-        const { headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+        const { headers, protocols, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
 
         const socket = await createWebSocketConnection({
             options: this._options,
             urlPath: "/v2/listen",
-            environmentKey: "production",
+            environmentKey: 'production',
             queryParams: buildQueryParams(args as Record<string, unknown>),
+            protocols,
+            service: "listen.v2",
             headers,
             debug,
             reconnectAttempts,
@@ -802,12 +1277,7 @@ class WrappedListenV2Client extends ListenV2Client {
      * socket.connect(); // Actually initiates the connection
      * ```
      */
-    public async createConnection(
-        args: Omit<ListenV2Client.ConnectArgs, "Authorization" | "keyterm"> & {
-            Authorization?: string;
-            keyterm?: string | string[];
-        },
-    ): Promise<ListenV2Socket> {
+    public async createConnection(args: Omit<ListenV2Client.ConnectArgs, "Authorization" | "keyterm"> & { Authorization?: string; keyterm?: string | string[] }): Promise<ListenV2Socket> {
         return this.connect(args);
     }
 }
@@ -840,7 +1310,7 @@ class WrappedListenV2Socket extends ListenV2Socket {
             handleOpen: socketAny.handleOpen,
             handleMessage: socketAny.handleMessage,
             handleClose: socketAny.handleClose,
-            handleError: socketAny.handleError,
+            handleError: socketAny.handleError
         });
 
         resetSocketConnectionState(this.socket);
@@ -878,8 +1348,8 @@ class WrappedListenV2Socket extends ListenV2Socket {
             // In browsers, WebSocket ping/pong is automatic and not exposed to JavaScript
             throw new Error(
                 "WebSocket ping is not supported in browser environments. " +
-                    "Browser WebSocket connections handle ping/pong automatically. " +
-                    "If you need keepalive in the browser, consider sending periodic audio data or using a timer.",
+                "Browser WebSocket connections handle ping/pong automatically. " +
+                "If you need keepalive in the browser, consider sending periodic audio data or using a timer."
             );
         }
     }
@@ -894,16 +1364,16 @@ class WrappedListenV2Socket extends ListenV2Socket {
  * connection setup, authentication, and header handling.
  */
 class WrappedSpeakV1Client extends SpeakV1Client {
-    public async connect(
-        args: Omit<SpeakV1Client.ConnectArgs, "Authorization"> & { Authorization?: string },
-    ): Promise<SpeakV1Socket> {
-        const { headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
+    public async connect(args: Omit<SpeakV1Client.ConnectArgs, "Authorization"> & { Authorization?: string }): Promise<SpeakV1Socket> {
+        const { headers, protocols, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } = args;
 
         const socket = await createWebSocketConnection({
             options: this._options,
             urlPath: "/v1/speak",
-            environmentKey: "production",
+            environmentKey: 'production',
             queryParams: buildQueryParams(args as Record<string, unknown>),
+            protocols,
+            service: "speak.v1",
             headers,
             debug,
             reconnectAttempts,
@@ -927,9 +1397,7 @@ class WrappedSpeakV1Client extends SpeakV1Client {
      * socket.connect(); // Actually initiates the connection
      * ```
      */
-    public async createConnection(
-        args: Omit<SpeakV1Client.ConnectArgs, "Authorization"> & { Authorization?: string },
-    ): Promise<SpeakV1Socket> {
+    public async createConnection(args: Omit<SpeakV1Client.ConnectArgs, "Authorization"> & { Authorization?: string }): Promise<SpeakV1Socket> {
         return this.connect(args);
     }
 }
@@ -968,7 +1436,7 @@ class WrappedSpeakV1Socket extends SpeakV1Socket {
             handleOpen: socketAny.handleOpen,
             handleMessage: socketAny.handleMessage,
             handleClose: socketAny.handleClose,
-            handleError: socketAny.handleError,
+            handleError: socketAny.handleError
         });
 
         resetSocketConnectionState(this.socket);

--- a/src/CustomClient.ts
+++ b/src/CustomClient.ts
@@ -209,6 +209,16 @@ export interface SpeakClientWithWebSockets extends SpeakClient {
 export interface CustomDeepgramClientOptions extends DeepgramClient.Options {
     accessToken?: core.Supplier<string | undefined>;
     transportFactory?: DeepgramTransportFactory;
+    /**
+     * Whether the SDK should retry streaming connections at the wrapper level
+     * after a transport failure. Defaults to `true` for native websocket
+     * connections. When a `transportFactory` is provided, this is auto-set to
+     * `false` because custom transports own their own retry/reconnect lifecycle
+     * — wrapping a self-retrying transport in another retry layer creates
+     * double-retry storms under burst load. Pass `reconnect: true` together
+     * with `transportFactory` to opt back into wrapper-level retries.
+     */
+    reconnect?: boolean;
 }
 
 export class CustomDeepgramClient extends DeepgramClient {
@@ -216,22 +226,30 @@ export class CustomDeepgramClient extends DeepgramClient {
     private _customListen: ListenClientWithWebSockets | undefined;
     private _customSpeak: SpeakClientWithWebSockets | undefined;
     private readonly _sessionId: string;
+    private readonly _reconnect: boolean;
 
     constructor(options: CustomDeepgramClientOptions = {}) {
         // Generate a UUID for the session ID
         const sessionId = generateUUID();
-        
+
         // Add the session ID to headers so it's included in all REST requests
+        // Auto-disable wrapper-level reconnect when a custom transportFactory
+        // is in use: those transports own their retry lifecycle, and stacking
+        // a second retry layer on top causes storm-on-storm under burst load.
+        // Callers can still opt back in by explicitly passing reconnect: true.
+        const reconnect = options.reconnect ?? (options.transportFactory == null);
         const optionsWithSessionId: CustomDeepgramClientOptions = {
             ...options,
+            reconnect,
             headers: {
                 ...options.headers,
                 "x-deepgram-session-id": sessionId,
             },
         };
-        
+
         super(optionsWithSessionId);
         this._sessionId = sessionId;
+        this._reconnect = reconnect;
 
         // Always wrap the auth provider to add "Token " prefix to API keys
         // The auto-generated HeaderAuthProvider doesn't add the prefix
@@ -252,6 +270,17 @@ export class CustomDeepgramClient extends DeepgramClient {
      */
     public get sessionId(): string {
         return this._sessionId;
+    }
+
+    /**
+     * Whether the SDK will retry streaming connections at the wrapper level
+     * after a transport-side failure. Returns `false` when a `transportFactory`
+     * was supplied without an explicit `reconnect: true` override, signalling
+     * that the custom transport is expected to manage its own reconnect
+     * lifecycle.
+     */
+    public get reconnect(): boolean {
+        return this._reconnect;
     }
 
     /**
@@ -401,6 +430,10 @@ function getTransportFactory(options: DeepgramClient.Options): DeepgramTransport
     return (options as CustomDeepgramClientOptions).transportFactory;
 }
 
+function getReconnect(options: DeepgramClient.Options): boolean {
+    return (options as CustomDeepgramClientOptions).reconnect !== false;
+}
+
 class TransportWebSocketAdapter {
     private _listeners: ReconnectingWebSocket.ListenersMap = {
         error: [],
@@ -427,10 +460,20 @@ class TransportWebSocketAdapter {
 
     private readonly _factory: DeepgramTransportFactory;
     private readonly _request: DeepgramTransportRequest;
+    // Whether the wrapper should retry after a transport-side failure. False
+    // signals that the underlying transport owns reconnect — the wrapper
+    // attempts the connect once and surfaces any error without re-attempting.
+    private readonly _reconnect: boolean;
 
-    constructor(args: { factory: DeepgramTransportFactory; request: DeepgramTransportRequest; startClosed?: boolean }) {
+    constructor(args: {
+        factory: DeepgramTransportFactory;
+        request: DeepgramTransportRequest;
+        startClosed?: boolean;
+        reconnect?: boolean;
+    }) {
         this._factory = args.factory;
         this._request = args.request;
+        this._reconnect = args.reconnect !== false;
         this._readyState = args.startClosed ? ReconnectingWebSocket.ReadyState.CLOSED : ReconnectingWebSocket.ReadyState.CONNECTING;
 
         if (this._request.abortSignal) {
@@ -603,6 +646,15 @@ class TransportWebSocketAdapter {
 
     private async _connect(): Promise<void> {
         if (this._connectLock || !this._shouldReconnect || this._request.abortSignal?.aborted) {
+            return;
+        }
+
+        // When wrapper-level reconnect is disabled, allow only the initial
+        // attempt (_retryCount starts at -1 and increments to 0 on first
+        // _connect). Any subsequent re-entry from _handleError must short out
+        // so the transport's own retry logic is the single source of truth.
+        if (!this._reconnect && this._retryCount >= 0) {
+            this._debug("reconnect disabled, skipping retry");
             return;
         }
 
@@ -1019,6 +1071,7 @@ async function createWebSocketConnection({
     const url = core.url.join(baseUrl, urlPath);
     const fullUrl = buildWebSocketUrl(url, queryParams);
     const transportFactory = getTransportFactory(options);
+    const reconnect = getReconnect(options);
 
     if (transportFactory) {
         const request: DeepgramTransportRequest = {
@@ -1038,6 +1091,7 @@ async function createWebSocketConnection({
             factory: transportFactory,
             request,
             startClosed: true,
+            reconnect,
         }) as unknown as ReconnectingWebSocket;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export * from "./api/resources/index.js";
 export type { BaseClientOptions, BaseRequestOptions } from "./BaseClient.js";
 export { DeepgramClient as DefaultDeepgramClient } from "./Client.js";
 export { CustomDeepgramClient as DeepgramClient } from "./CustomClient.js";
+export type { CustomDeepgramClientOptions } from "./CustomClient.js";
 export { DeepgramEnvironment, type DeepgramEnvironmentUrls } from "./environments.js";
 export { DeepgramError, DeepgramTimeoutError } from "./errors/index.js";
+export * from "./transport.js";
 export * from "./exports.js";

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,81 @@
+/**
+ * Message payloads exchanged over Deepgram streaming transports.
+ *
+ * A transport can carry JSON control messages as strings and audio or synthesized
+ * audio as binary payloads.
+ */
+export type DeepgramTransportMessage = string | ArrayBuffer | Blob | ArrayBufferView;
+
+/** Close metadata reported by a custom transport. */
+export interface DeepgramTransportCloseEvent {
+    code?: number;
+    reason?: string;
+}
+
+/**
+ * Metadata passed to a transport factory when a streaming connection is created.
+ *
+ * The first two factory arguments intentionally match the Python and Java SDKs:
+ * `factory(url, headers)`. JavaScript also passes this third metadata object so
+ * custom transports can inspect the target streaming API and connection settings.
+ */
+export interface DeepgramTransportRequest {
+    /** Full Deepgram websocket URL including query parameters. */
+    url: string;
+    /** Resolved request headers including auth and session headers. */
+    headers: Record<string, string>;
+    /** Requested websocket subprotocols, if any. */
+    protocols: string[];
+    /** Deepgram websocket path (for example `/v1/listen`). */
+    path: string;
+    /** Streaming API being targeted. */
+    service: "agent.v1" | "listen.v1" | "listen.v2" | "speak.v1";
+    /** Query parameters before they are encoded into the URL. */
+    queryParams: Record<string, unknown>;
+    /** Whether debug logging was requested for the connection. */
+    debug: boolean;
+    /** Requested reconnect attempts for this connection. */
+    reconnectAttempts: number;
+    /** Optional connection timeout in seconds. */
+    connectionTimeoutInSeconds?: number;
+    /** Optional abort signal for the connection attempt. */
+    abortSignal?: AbortSignal;
+}
+
+/**
+ * Transport interface for replacing the SDK's default websocket transport.
+ *
+ * This is the seam used by SageMaker support and other non-websocket streaming
+ * implementations. The SDK adapts this transport to its existing socket APIs, so
+ * callers still use `client.listen.v1.createConnection()` and related methods.
+ */
+export interface DeepgramTransport {
+    /** Send either a JSON string or binary payload to the transport. */
+    send(data: DeepgramTransportMessage): void | Promise<void>;
+    /** Register a listener fired once the transport is ready to exchange messages. */
+    onOpen(listener: () => void): void;
+    /** Register a listener for inbound text or binary messages. */
+    onMessage(listener: (message: DeepgramTransportMessage) => void): void;
+    /** Register a listener for transport-level errors. */
+    onError(listener: (error: Error) => void): void;
+    /** Register a listener for transport close events. */
+    onClose(listener: (event: DeepgramTransportCloseEvent) => void): void;
+    /** Returns true while the transport is open and able to send data. */
+    isOpen(): boolean;
+    /** Close the transport gracefully. */
+    close(code?: number, reason?: string): void | Promise<void>;
+    /** Optional ping hook for transports that expose an explicit keepalive primitive. */
+    ping?(data?: string | ArrayBuffer | Blob | ArrayBufferView): void | Promise<void>;
+}
+
+/**
+ * Factory for creating custom streaming transports.
+ *
+ * The first two arguments mirror the Python and Java SDKs. JavaScript also passes
+ * a third metadata argument for transports that need more connection context.
+ */
+export type DeepgramTransportFactory = (
+    url: string,
+    headers: Record<string, string>,
+    request: DeepgramTransportRequest,
+) => DeepgramTransport | Promise<DeepgramTransport>;

--- a/tests/unit/transport-factory.test.ts
+++ b/tests/unit/transport-factory.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { DeepgramClient, type DeepgramTransport, type DeepgramTransportFactory } from "../../src";
+
+type ListenerMap = {
+    open?: () => void;
+    message?: (message: string | ArrayBuffer | Blob | ArrayBufferView) => void;
+    error?: (error: Error) => void;
+    close?: (event: { code?: number; reason?: string }) => void;
+};
+
+class FakeTransport implements DeepgramTransport {
+    public readonly listeners: ListenerMap = {};
+    public readonly sent: Array<string | ArrayBuffer | Blob | ArrayBufferView> = [];
+    public closed = false;
+    public pingPayloads: Array<string | ArrayBuffer | Blob | ArrayBufferView | undefined> = [];
+    private open = false;
+
+    public send(data: string | ArrayBuffer | Blob | ArrayBufferView): void {
+        this.sent.push(data);
+    }
+
+    public onOpen(listener: () => void): void {
+        this.listeners.open = listener;
+    }
+
+    public onMessage(listener: (message: string | ArrayBuffer | Blob | ArrayBufferView) => void): void {
+        this.listeners.message = listener;
+    }
+
+    public onError(listener: (error: Error) => void): void {
+        this.listeners.error = listener;
+    }
+
+    public onClose(listener: (event: { code?: number; reason?: string }) => void): void {
+        this.listeners.close = listener;
+    }
+
+    public isOpen(): boolean {
+        return this.open;
+    }
+
+    public close(code?: number, reason?: string): void {
+        this.closed = true;
+        this.open = false;
+        this.listeners.close?.({ code, reason });
+    }
+
+    public ping(data?: string | ArrayBuffer | Blob | ArrayBufferView): void {
+        this.pingPayloads.push(data);
+    }
+
+    public emitOpen(): void {
+        this.open = true;
+        this.listeners.open?.();
+    }
+
+    public emitMessage(message: string | ArrayBuffer | Blob | ArrayBufferView): void {
+        this.listeners.message?.(message);
+    }
+}
+
+describe("transportFactory", () => {
+    it("routes listen websocket connections through the custom transport", async () => {
+        const created: Array<{ url: string; headers: Record<string, string>; request: { service: string } }> = [];
+        const transport = new FakeTransport();
+
+        const transportFactory: DeepgramTransportFactory = (url, headers, request) => {
+            created.push({ url, headers, request: { service: request.service } });
+            return transport;
+        };
+
+        const client = new DeepgramClient({
+            apiKey: "test-api-key",
+            transportFactory,
+        });
+
+        const socket = await client.listen.v1.createConnection({ model: "nova-3" });
+        let opened = false;
+        let receivedType: string | undefined;
+
+        socket.on("open", () => {
+            opened = true;
+        });
+        socket.on("message", (message: any) => {
+            receivedType = message.type;
+        });
+
+        socket.connect();
+        await Promise.resolve();
+
+        expect(created).toHaveLength(1);
+        expect(created[0]?.url).toContain("wss://api.deepgram.com/v1/listen");
+        expect(created[0]?.url).toContain("model=nova-3");
+        expect(created[0]?.headers.Authorization ?? created[0]?.headers.authorization).toBe("Token test-api-key");
+        expect(created[0]?.headers["x-deepgram-session-id"]).toBeTruthy();
+        expect(created[0]?.request.service).toBe("listen.v1");
+
+        transport.emitOpen();
+        expect(opened).toBe(true);
+
+        socket.sendMedia(new Uint8Array([1, 2, 3]));
+        expect(transport.sent).toHaveLength(1);
+        expect(transport.sent[0]).toBeInstanceOf(Uint8Array);
+
+        transport.emitMessage('{"type":"Results"}');
+        expect(receivedType).toBe("Results");
+
+        socket.close();
+        expect(transport.closed).toBe(true);
+    });
+
+    it("exposes transport ping through listen.v2 sockets when available", async () => {
+        const transport = new FakeTransport();
+        const client = new DeepgramClient({
+            apiKey: "test-api-key",
+            transportFactory: () => transport,
+        });
+
+        const socket = await client.listen.v2.createConnection({ model: "flux-general-en" });
+        socket.connect();
+        await Promise.resolve();
+        transport.emitOpen();
+
+        socket.ping("keepalive");
+        expect(transport.pingPayloads).toEqual(["keepalive"]);
+    });
+});

--- a/tests/unit/transport-factory.test.ts
+++ b/tests/unit/transport-factory.test.ts
@@ -126,3 +126,105 @@ describe("transportFactory", () => {
         expect(transport.pingPayloads).toEqual(["keepalive"]);
     });
 });
+
+describe("reconnect flag", () => {
+    it("defaults to true for native websocket clients", () => {
+        const client = new DeepgramClient({ apiKey: "test-api-key" });
+        expect(client.reconnect).toBe(true);
+    });
+
+    it("honors explicit reconnect: false", () => {
+        const client = new DeepgramClient({ apiKey: "test-api-key", reconnect: false });
+        expect(client.reconnect).toBe(false);
+    });
+
+    it("auto-disables reconnect when a transportFactory is supplied", () => {
+        const transport = new FakeTransport();
+        const client = new DeepgramClient({
+            apiKey: "test-api-key",
+            transportFactory: () => transport,
+        });
+        expect(client.reconnect).toBe(false);
+    });
+
+    it("respects an explicit reconnect: true override even with transportFactory", () => {
+        const transport = new FakeTransport();
+        const client = new DeepgramClient({
+            apiKey: "test-api-key",
+            transportFactory: () => transport,
+            reconnect: true,
+        });
+        expect(client.reconnect).toBe(true);
+    });
+
+    it("does not retry the factory after a transport error when reconnect is disabled", async () => {
+        let callCount = 0;
+        const transport = new FakeTransport();
+
+        const transportFactory: DeepgramTransportFactory = () => {
+            callCount += 1;
+            return transport;
+        };
+
+        const client = new DeepgramClient({
+            apiKey: "test-api-key",
+            transportFactory,
+            // explicit for clarity; auto-disabled either way
+            reconnect: false,
+        });
+
+        const socket = await client.listen.v1.createConnection({ model: "nova-3" });
+        socket.on("error", () => {
+            // listener kept so the error event doesn't bubble out of the test
+        });
+        socket.connect();
+        await Promise.resolve();
+
+        expect(callCount).toBe(1);
+
+        // Simulate a transport-side failure mid-stream
+        transport.listeners.error?.(new Error("simulated failure"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // The wrapper must not have re-invoked the factory.
+        expect(callCount).toBe(1);
+    });
+
+    it("retries the factory after a transport error when reconnect is enabled", async () => {
+        let callCount = 0;
+        const transports: FakeTransport[] = [];
+
+        const transportFactory: DeepgramTransportFactory = () => {
+            callCount += 1;
+            const t = new FakeTransport();
+            transports.push(t);
+            return t;
+        };
+
+        const client = new DeepgramClient({
+            apiKey: "test-api-key",
+            transportFactory,
+            // opt back in to wrapper retries
+            reconnect: true,
+        });
+
+        const socket = await client.listen.v1.createConnection({
+            model: "nova-3",
+            reconnectAttempts: 3,
+        });
+        socket.on("error", () => {
+            // swallow errors so the test runner doesn't fail on them
+        });
+        socket.connect();
+        await Promise.resolve();
+
+        expect(callCount).toBe(1);
+
+        transports[0]!.listeners.error?.(new Error("simulated failure"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(callCount).toBe(2);
+    });
+});


### PR DESCRIPTION
## Proposed changes

Adds a pluggable streaming-transport interface so the JS SDK can route `listen.v1`, `listen.v2`, `speak.v1`, and `agent.v1` connections through a custom transport instead of the default WebSocket. Also adds a `reconnect` parity flag for clean handoff of retry responsibility to custom transports.

This is the JS half of the cross-SDK pluggable-transport work that's also landed in Python and Java for SageMaker support.

### What's new

1. **`DeepgramTransport` / `DeepgramTransportFactory` interface** (`src/transport.ts`)
   - Hand-maintained type surface that custom transports implement
   - Same `factory(url, headers, request)` shape as the Python/Java equivalents, with JS-specific request metadata as a third argument

2. **`transportFactory` option on `DeepgramClient`** (wired in `src/CustomClient.ts`)
   - When set, `listen.v1` / `listen.v2` / `speak.v1` / `agent.v1` `createConnection` paths build a `TransportWebSocketAdapter` that exposes the SDK's expected `ReconnectingWebSocket` surface but delegates to the custom transport underneath
   - REST behaviour stays unchanged; only the streaming connection layer is pluggable

3. **`reconnect` flag with auto-disable** (commit `b82d30b`)
   - New `reconnect?: boolean` option on `DeepgramClient`
   - Default is `true` (SDK manages reconnects, current behaviour)
   - When `transportFactory` is set, auto-disabled to `false` — the custom transport owns its retry/reconnect lifecycle; double-stacking the SDK's wrapper retries on top would cause storm-on-storm under burst load
   - Callers can still opt back in with explicit `reconnect: true`
   - Exposed read-only as `client.reconnect`

### Context

- This is the SDK seam that `@deepgram/sagemaker` (`deepgram-js-sdk-transport-sagemaker`) plugs into. That package's `createSageMakerTransportFactory` returns a `DeepgramTransportFactory` matching this interface.
- The `reconnect` flag mirrors the same parity work in:
  - `deepgram-java-sdk` 
  - `deepgram-python-sdk` #720
- The JS half of this work has been validated end-to-end against three live SageMaker endpoints (Nova-3 STT, Flux, Aura TTS), including a 400-concurrent-connection burst against Nova-3 with mean WER 0.10% — matching Java's reference test.

## Testing

- `pnpm build`
- `pnpm vitest run tests/unit/transport-factory.test.ts` — adapter-path unit coverage including reconnect-flag defaults, explicit `reconnect: false`, `transportFactory` auto-disable, and explicit `reconnect: true` override
- `pnpm vitest run tests/unit/custom-client.test.ts`
- End-to-end validation against live SageMaker endpoints (Nova-3 STT, Flux, Aura TTS); see the `@deepgram/sagemaker` package for the transport implementation those tests exercise

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Release impact

- `feat:` per commit message → minor version bump per release-please
- Fully backwards-compatible — both `transportFactory` and `reconnect` are optional kwargs with sensible defaults; existing callers need no code changes
- Hand-maintained files added to `.fernignore` so Fern regen doesn't overwrite them

## Companion packages

This PR provides the SDK-side interface. The first consumer is:

- `@deepgram/sagemaker` (repo: `deepgram-js-sdk-transport-sagemaker`) — SageMaker bidirectional HTTP/2 transport, validated end-to-end at 400 concurrent connections

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
