### PR TITLE
docs: document AbortSignal for real-time connect()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help examples example-1 example-2 example-3 example-4 example-5 example-6 example-7 example-8 example-9 example-10 example-11 example-12 example-13 example-14 example-15 example-16 example-17 example-18 example-19 example-20 example-21 example-22 example-23 example-24 example-25 example-26 example-27 example-28 example-29 example-30 example-31 example-32 example-33 example-34 example-35 example-36 test test-esm lint build browser browser-serve
+.PHONY: help examples example-1 example-2 example-3 example-4 example-5 example-6 example-7 example-8 example-9 example-10 example-11 example-12 example-13 example-14 example-15 example-16 example-17 example-18 example-19 example-20 example-21 example-22 example-23 example-24 example-25 example-26 example-27 example-28 example-29 example-30 example-31 example-32 example-33 example-34 example-35 example-36 example-37 test test-esm lint build browser browser-serve
 
 # Default target
 help:
@@ -11,7 +11,7 @@ help:
 	@printf "  \033[1;32mmake test-esm\033[0m          - Run ESM build validation tests\n"
 	@echo ""
 	@printf "\033[1;33mExample Commands:\033[0m\n"
-	@printf "  \033[1;32mmake examples\033[0m          - Run all example scripts (1-32) sequentially\n"
+	@printf "  \033[1;32mmake examples\033[0m          - Run all example scripts (1-37) sequentially\n"
 	@printf "  \033[1;32mmake example-N\033[0m         - Run a specific example by number (e.g., make example-1)\n"
 	@printf "  \033[1;32mmake browser\033[0m           - Run browser tests\n"
 	@printf "  \033[1;32mmake browser-serve\033[0m     - Serve the browser examples for manual testing\n"
@@ -53,6 +53,7 @@ help:
 	@printf "  \033[36m34\033[0m - Agent Custom Providers\n"
 	@printf "  \033[36m35\033[0m - Agent Provider Combinations\n"
 	@printf "  \033[36m36\033[0m - Agent Inject Message\n"
+	@printf "  \033[36m37\033[0m - AbortSignal Cancellation\n"
 
 # Run all examples
 examples:
@@ -136,6 +137,7 @@ examples:
 	run_example 34 "examples/34-agent-custom-providers.ts" "Agent Custom Providers"; \
 	run_example 35 "examples/35-agent-provider-combinations.ts" "Agent Provider Combinations"; \
 	run_example 36 "examples/36-agent-inject-message.ts" "Agent Inject Message"; \
+	run_example 37 "examples/37-abortsignal-cancellation.ts" "AbortSignal Cancellation"; \
 	\
 	printf "\n\033[1;36m=========================================\033[0m\n"; \
 	printf "\033[1;36mSummary Report\033[0m\n"; \
@@ -279,6 +281,9 @@ example-35:
 
 example-36:
 	pnpm exec tsx examples/36-agent-inject-message.ts
+
+example-37:
+	pnpm exec tsx examples/37-abortsignal-cancellation.ts
 
 lint:
 	pnpm exec biome lint --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help examples example-1 example-2 example-3 example-4 example-5 example-6 example-7 example-8 example-9 example-10 example-11 example-12 example-13 example-14 example-15 example-16 example-17 example-18 example-19 example-20 example-21 example-22 example-23 example-24 example-25 example-26 example-27 example-28 example-29 example-30 example-31 example-32 example-33 example-34 example-35 example-36 example-37 example-38 test test-esm typecheck-tests lint build browser browser-serve
+.PHONY: help examples example-1 example-2 example-3 example-4 example-5 example-6 example-7 example-8 example-9 example-10 example-11 example-12 example-13 example-14 example-15 example-16 example-17 example-18 example-19 example-20 example-21 example-22 example-23 example-24 example-25 example-26 example-27 example-28 example-29 example-30 example-31 example-32 example-33 example-34 example-35 example-36 example-37 example-38 example-39 example-40 test test-esm typecheck-tests lint build browser browser-serve
 
 # Default target
 help:
@@ -11,7 +11,7 @@ help:
 	@printf "  \033[1;32mmake test-esm\033[0m          - Run ESM build validation tests\n"
 	@echo ""
 	@printf "\033[1;33mExample Commands:\033[0m\n"
-	@printf "  \033[1;32mmake examples\033[0m          - Run all example scripts (1-38) sequentially\n"
+	@printf "  \033[1;32mmake examples\033[0m          - Run all example scripts (1-40) sequentially\n"
 	@printf "  \033[1;32mmake example-N\033[0m         - Run a specific example by number (e.g., make example-1)\n"
 	@printf "  \033[1;32mmake browser\033[0m           - Run browser tests\n"
 	@printf "  \033[1;32mmake browser-serve\033[0m     - Serve the browser examples for manual testing\n"
@@ -53,11 +53,15 @@ help:
 	@printf "  \033[36m34\033[0m - Agent Custom Providers\n"
 	@printf "  \033[36m35\033[0m - Agent Provider Combinations\n"
 	@printf "  \033[36m36\033[0m - Agent Inject Message\n"
+	@printf "  \033[36m37\033[0m - Text-to-Speech Streaming Flux (v2)\n"
+	@printf "  \033[36m38\033[0m - Transcription Flux End-of-Turn\n"
+	@printf "  \033[36m39\033[0m - Transcription Flux Force-End-Turn\n"
+	@printf "  \033[36m40\033[0m - AbortSignal Cancellation\n"
 
 # Run all examples
 examples:
 	@printf "\033[1;36mRunning all examples...\033[0m\n\n"; \
-	TOTAL=39; \
+	TOTAL=40; \
 	PASS_COUNT=0; \
 	FAIL_COUNT=0; \
 	PASSED_LIST=""; \
@@ -136,9 +140,10 @@ examples:
 	run_example 34 "examples/34-agent-custom-providers.ts" "Agent Custom Providers"; \
 	run_example 35 "examples/35-agent-provider-combinations.ts" "Agent Provider Combinations"; \
 	run_example 36 "examples/36-agent-inject-message.ts" "Agent Inject Message"; \
-		run_example 37 "examples/37-text-to-speech-streaming-flux.ts" "Text-to-Speech Streaming Flux (v2)"; \
-		run_example 38 "examples/38-transcription-flux-eot.ts" "Transcription Flux End-of-Turn"; \
-		run_example 39 "examples/39-transcription-flux-force-end-turn.ts" "Transcription Flux Force-End-Turn"; \
+	run_example 37 "examples/37-text-to-speech-streaming-flux.ts" "Text-to-Speech Streaming Flux (v2)"; \
+	run_example 38 "examples/38-transcription-flux-eot.ts" "Transcription Flux End-of-Turn"; \
+	run_example 39 "examples/39-transcription-flux-force-end-turn.ts" "Transcription Flux Force-End-Turn"; \
+	run_example 40 "examples/40-abortsignal-cancellation.ts" "AbortSignal Cancellation"; \
 	\
 	printf "\n\033[1;36m=========================================\033[0m\n"; \
 	printf "\033[1;36mSummary Report\033[0m\n"; \
@@ -288,6 +293,12 @@ example-37:
 
 example-38:
 	pnpm exec tsx examples/38-transcription-flux-eot.ts
+
+example-39:
+	pnpm exec tsx examples/39-transcription-flux-force-end-turn.ts
+
+example-40:
+	pnpm exec tsx examples/40-abortsignal-cancellation.ts
 
 lint:
 	pnpm exec biome lint --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ await connection.waitForOpen();
 connection.socket.send(audioData);
 ```
 
+Pass an `abortSignal` to `connect()` to safely cancel a session, even one that hasn't finished connecting yet, and tear down all listeners. See [Canceling a WebSocket Connection (AbortSignal)](#canceling-a-websocket-connection-abortsignal).
+
 #### File Transcription
 
 Transcribe pre-recorded audio files ([API Reference](./reference.md)):
@@ -294,6 +296,42 @@ const response = await client.listen.v1.media.transcribeFile(audioData, {
   maxRetries: 3,
 });
 ```
+
+### Canceling a WebSocket Connection (AbortSignal)
+
+All real-time `connect()` methods — `listen.v1.connect()`, `agent.v1.connect()`, and
+`speak.v1.connect()` — accept an `abortSignal`. This is the recommended way to cancel a
+connection, especially in apps that start and stop sessions rapidly (Electron, Node.js
+backends, etc.).
+
+When the signal aborts, the SDK closes the underlying WebSocket, disables automatic
+reconnection, and removes its internal event listeners so no `open` / `close` / `error`
+handlers fire afterwards and no dangling reconnect loop is left behind. It is also the only
+safe way to cancel a connection that is still opening, before the socket has finished
+connecting.
+
+```typescript
+import { DeepgramClient } from "@deepgram/sdk";
+
+const client = new DeepgramClient();
+const controller = new AbortController();
+
+const connection = await client.listen.v1.connect({
+  model: "nova-3",
+  language: "en",
+  abortSignal: controller.signal,
+});
+
+connection.on("open", () => console.log("Connection opened"));
+connection.on("message", (data) => console.log(data));
+
+connection.connect();
+
+// Cancel the session later, e.g. when the user stops it or before it finishes connecting
+controller.abort();
+```
+
+An aborted signal is terminal: it tears the connection down for good. To start a new session, create a fresh `AbortController` and call `connect()` again.
 
 ### Access Raw Response Data
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ await connection.waitForOpen();
 connection.socket.send(audioData);
 ```
 
-Pass an `abortSignal` to `connect()` to safely cancel a session, even one that hasn't finished connecting yet, and tear down all listeners. See [Canceling a WebSocket Connection (AbortSignal)](#canceling-a-websocket-connection-abortsignal).
+Pass an `abortSignal` to stop a connection attempt or active session and disable automatic reconnection. If you await `waitForOpen()`, make that wait abort-aware as shown in [Canceling a WebSocket Connection (AbortSignal)](#canceling-a-websocket-connection-abortsignal).
 
 #### File Transcription
 
@@ -303,22 +303,51 @@ const response = await client.listen.v1.media.transcribeFile(audioData, {
 
 ### Canceling a WebSocket Connection (AbortSignal)
 
-All real-time `connect()` methods — `listen.v1.connect()`, `agent.v1.connect()`, and
-`speak.v1.connect()` — accept an `abortSignal`. This is the recommended way to cancel a
-connection, especially in apps that start and stop sessions rapidly (Electron, Node.js
-backends, etc.).
+All real-time `connect()` methods — `listen.v1.connect()`, `listen.v2.connect()`,
+`agent.v1.connect()`, `speak.v1.connect()`, and `speak.v2.connect()` — accept an
+`abortSignal`. Use it when cancellation must be controlled outside the connection owner,
+such as in apps that start and stop sessions rapidly.
 
-When the signal aborts, the SDK closes the underlying WebSocket, disables automatic
-reconnection, and removes its internal event listeners so no `open` / `close` / `error`
-handlers fire afterwards and no dangling reconnect loop is left behind. It is also the only
-safe way to cancel a connection that is still opening, before the socket has finished
-connecting.
+When the signal aborts, the SDK stops the pending or active transport and disables automatic
+reconnection. A registered `close` callback can run as part of cancellation. AbortSignal does
+not clear callbacks registered with `connection.on()`, and `waitForOpen()` does not observe the
+signal directly. If a connection can be canceled while opening, make the wait abort-aware:
 
 ```typescript
 import { DeepgramClient } from "@deepgram/sdk";
 
 const client = new DeepgramClient();
 const controller = new AbortController();
+
+function waitForOpenOrAbort(
+  connection: { waitForOpen(): Promise<unknown> },
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(signal.reason ?? new Error("Connection aborted"));
+    };
+
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    connection.waitForOpen().then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
 
 const connection = await client.listen.v1.connect({
   model: "nova-3",
@@ -330,12 +359,15 @@ connection.on("open", () => console.log("Connection opened"));
 connection.on("message", (data) => console.log(data));
 
 connection.connect();
+await waitForOpenOrAbort(connection, controller.signal);
 
-// Cancel the session later, e.g. when the user stops it or before it finishes connecting
+// Cancel the session later. If this happens before open, the helper above rejects.
 controller.abort();
 ```
 
-An aborted signal is terminal: it tears the connection down for good. To start a new session, create a fresh `AbortController` and call `connect()` again.
+An aborted signal is terminal for that connection. To start a new session, create a fresh
+`AbortController` and connection. AbortSignal does not provide `removeAllListeners()`; manage
+the lifecycle of callbacks registered on the old connection separately.
 
 ### Access Raw Response Data
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ await connection.waitForOpen();
 connection.socket.send(audioData);
 ```
 
+Pass an `abortSignal` to `connect()` to safely cancel a session, even one that hasn't finished connecting yet, and tear down all listeners. See [Canceling a WebSocket Connection (AbortSignal)](#canceling-a-websocket-connection-abortsignal).
+
 #### File Transcription
 
 Transcribe pre-recorded audio files ([API Reference](./reference.md)):
@@ -298,6 +300,42 @@ const response = await client.listen.v1.media.transcribeFile(audioData, {
   maxRetries: 3,
 });
 ```
+
+### Canceling a WebSocket Connection (AbortSignal)
+
+All real-time `connect()` methods — `listen.v1.connect()`, `agent.v1.connect()`, and
+`speak.v1.connect()` — accept an `abortSignal`. This is the recommended way to cancel a
+connection, especially in apps that start and stop sessions rapidly (Electron, Node.js
+backends, etc.).
+
+When the signal aborts, the SDK closes the underlying WebSocket, disables automatic
+reconnection, and removes its internal event listeners so no `open` / `close` / `error`
+handlers fire afterwards and no dangling reconnect loop is left behind. It is also the only
+safe way to cancel a connection that is still opening, before the socket has finished
+connecting.
+
+```typescript
+import { DeepgramClient } from "@deepgram/sdk";
+
+const client = new DeepgramClient();
+const controller = new AbortController();
+
+const connection = await client.listen.v1.connect({
+  model: "nova-3",
+  language: "en",
+  abortSignal: controller.signal,
+});
+
+connection.on("open", () => console.log("Connection opened"));
+connection.on("message", (data) => console.log(data));
+
+connection.connect();
+
+// Cancel the session later, e.g. when the user stops it or before it finishes connecting
+controller.abort();
+```
+
+An aborted signal is terminal: it tears the connection down for good. To start a new session, create a fresh `AbortController` and call `connect()` again.
 
 ### Access Raw Response Data
 

--- a/examples/37-abortsignal-cancellation.ts
+++ b/examples/37-abortsignal-cancellation.ts
@@ -1,0 +1,81 @@
+/**
+ * Example: Canceling a Live Connection with AbortSignal
+ *
+ * Demonstrates how to safely cancel a real-time connection using an
+ * AbortSignal. Aborting closes the WebSocket, disables automatic
+ * reconnection, and removes the SDK's internal event listeners, so no
+ * stray open/close/error handlers fire afterwards and no reconnect loop
+ * is left behind. It is also the only safe way to cancel a connection
+ * that is still opening.
+ *
+ * The same abortSignal option works for agent.v1.connect() and
+ * speak.v1.connect() as well.
+ */
+
+const { DeepgramClient } = require("../dist/cjs/index.js");
+const { createReadStream } = require("fs");
+
+const deepgramClient = new DeepgramClient({
+    apiKey: process.env.DEEPGRAM_API_KEY,
+});
+
+async function abortSignalCancellation() {
+    // Create an AbortController; its signal cancels the connection on demand
+    const controller = new AbortController();
+
+    try {
+        // Pass the signal when creating the connection
+        const deepgramConnection = await deepgramClient.listen.v1.createConnection({
+            model: "nova-3",
+            language: "en",
+            interim_results: "true",
+            abortSignal: controller.signal,
+        });
+
+        deepgramConnection.on("open", () => {
+            console.log("Connection opened");
+        });
+
+        deepgramConnection.on("message", (data) => {
+            if (data.type === "Results") {
+                const transcript = data.channel?.alternatives?.[0]?.transcript;
+                if (transcript) {
+                    console.log("Transcript:", transcript);
+                }
+            }
+        });
+
+        deepgramConnection.on("error", (error) => {
+            console.error("Error:", error);
+        });
+
+        deepgramConnection.on("close", () => {
+            console.log("Connection closed");
+        });
+
+        // Open the websocket
+        deepgramConnection.connect();
+        await deepgramConnection.waitForOpen();
+
+        // Stream some audio from a file
+        const audioStream = createReadStream("./examples/spacewalk.wav");
+        audioStream.on("data", (chunk) => {
+            deepgramConnection.sendMedia(chunk);
+        });
+
+        // Simulate the user stopping the session after a short delay.
+        // Aborting tears the connection down for good: the socket closes,
+        // reconnection is disabled, and internal listeners are removed.
+        setTimeout(() => {
+            console.log("Stopping session, aborting connection...");
+            controller.abort();
+            console.log("Connection aborted; no reconnect will occur.");
+            process.exit(0);
+        }, 3000);
+    } catch (error) {
+        console.error("Error setting up connection:", error);
+        process.exit(1);
+    }
+}
+
+abortSignalCancellation();

--- a/examples/40-abortsignal-cancellation.ts
+++ b/examples/40-abortsignal-cancellation.ts
@@ -1,0 +1,81 @@
+/**
+ * Example: Canceling a Live Connection with AbortSignal
+ *
+ * Demonstrates how to safely cancel a real-time connection using an
+ * AbortSignal. Aborting closes the WebSocket, disables automatic
+ * reconnection, and removes the SDK's internal event listeners, so no
+ * stray open/close/error handlers fire afterwards and no reconnect loop
+ * is left behind. It is also the only safe way to cancel a connection
+ * that is still opening.
+ *
+ * The same abortSignal option works for agent.v1.connect() and
+ * speak.v1.connect() as well.
+ */
+
+const { DeepgramClient } = require("../dist/cjs/index.js");
+const { createReadStream } = require("fs");
+
+const deepgramClient = new DeepgramClient({
+    apiKey: process.env.DEEPGRAM_API_KEY,
+});
+
+async function abortSignalCancellation() {
+    // Create an AbortController; its signal cancels the connection on demand
+    const controller = new AbortController();
+
+    try {
+        // Pass the signal when creating the connection
+        const deepgramConnection = await deepgramClient.listen.v1.createConnection({
+            model: "nova-3",
+            language: "en",
+            interim_results: "true",
+            abortSignal: controller.signal,
+        });
+
+        deepgramConnection.on("open", () => {
+            console.log("Connection opened");
+        });
+
+        deepgramConnection.on("message", (data) => {
+            if (data.type === "Results") {
+                const transcript = data.channel?.alternatives?.[0]?.transcript;
+                if (transcript) {
+                    console.log("Transcript:", transcript);
+                }
+            }
+        });
+
+        deepgramConnection.on("error", (error) => {
+            console.error("Error:", error);
+        });
+
+        deepgramConnection.on("close", () => {
+            console.log("Connection closed");
+        });
+
+        // Open the websocket
+        deepgramConnection.connect();
+        await deepgramConnection.waitForOpen();
+
+        // Stream some audio from a file
+        const audioStream = createReadStream("./examples/spacewalk.wav");
+        audioStream.on("data", (chunk) => {
+            deepgramConnection.sendMedia(chunk);
+        });
+
+        // Simulate the user stopping the session after a short delay.
+        // Aborting tears the connection down for good: the socket closes,
+        // reconnection is disabled, and internal listeners are removed.
+        setTimeout(() => {
+            console.log("Stopping session, aborting connection...");
+            controller.abort();
+            console.log("Connection aborted; no reconnect will occur.");
+            process.exit(0);
+        }, 3000);
+    } catch (error) {
+        console.error("Error setting up connection:", error);
+        process.exit(1);
+    }
+}
+
+abortSignalCancellation();

--- a/examples/40-abortsignal-cancellation.ts
+++ b/examples/40-abortsignal-cancellation.ts
@@ -1,15 +1,13 @@
 /**
  * Example: Canceling a Live Connection with AbortSignal
  *
- * Demonstrates how to safely cancel a real-time connection using an
- * AbortSignal. Aborting closes the WebSocket, disables automatic
- * reconnection, and removes the SDK's internal event listeners, so no
- * stray open/close/error handlers fire afterwards and no reconnect loop
- * is left behind. It is also the only safe way to cancel a connection
- * that is still opening.
+ * Demonstrates how to cancel a real-time connection using an AbortSignal.
+ * Aborting stops the pending or active transport and disables automatic
+ * reconnection. It does not remove callbacks registered with connection.on(),
+ * and waitForOpen() must be made abort-aware separately.
  *
- * The same abortSignal option works for agent.v1.connect() and
- * speak.v1.connect() as well.
+ * The same abortSignal option works for listen.v2, agent.v1, speak.v1,
+ * and speak.v2 connections.
  */
 
 const { DeepgramClient } = require("../dist/cjs/index.js");
@@ -19,9 +17,38 @@ const deepgramClient = new DeepgramClient({
     apiKey: process.env.DEEPGRAM_API_KEY,
 });
 
+function waitForOpenOrAbort(connection: { waitForOpen(): Promise<unknown> }, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const cleanup = () => signal.removeEventListener("abort", onAbort);
+        const onAbort = () => {
+            cleanup();
+            reject(signal.reason ?? new Error("Connection aborted"));
+        };
+
+        if (signal.aborted) {
+            onAbort();
+            return;
+        }
+
+        signal.addEventListener("abort", onAbort, { once: true });
+        connection.waitForOpen().then(
+            () => {
+                cleanup();
+                resolve();
+            },
+            (error) => {
+                cleanup();
+                reject(error);
+            },
+        );
+    });
+}
+
 async function abortSignalCancellation() {
     // Create an AbortController; its signal cancels the connection on demand
     const controller = new AbortController();
+    let audioStream: ReturnType<typeof createReadStream> | undefined;
+    let abortTimer: ReturnType<typeof setTimeout> | undefined;
 
     try {
         // Pass the signal when creating the connection
@@ -36,45 +63,57 @@ async function abortSignalCancellation() {
             console.log("Connection opened");
         });
 
-        deepgramConnection.on("message", (data) => {
-            if (data.type === "Results") {
-                const transcript = data.channel?.alternatives?.[0]?.transcript;
-                if (transcript) {
-                    console.log("Transcript:", transcript);
+        deepgramConnection.on(
+            "message",
+            (data: { type?: string; channel?: { alternatives?: Array<{ transcript?: string }> } }) => {
+                if (data.type === "Results") {
+                    const transcript = data.channel?.alternatives?.[0]?.transcript;
+                    if (transcript) {
+                        console.log("Transcript:", transcript);
+                    }
                 }
-            }
-        });
+            },
+        );
 
-        deepgramConnection.on("error", (error) => {
+        deepgramConnection.on("error", (error: unknown) => {
             console.error("Error:", error);
         });
 
-        deepgramConnection.on("close", () => {
-            console.log("Connection closed");
+        const connectionClosed = new Promise<void>((resolve) => {
+            deepgramConnection.on("close", () => {
+                console.log("Connection closed");
+                resolve();
+            });
         });
 
-        // Open the websocket
+        // Schedule cancellation before opening so the same path also handles a
+        // slow connection that is still opening after three seconds.
+        abortTimer = setTimeout(() => {
+            console.log("Stopping session, aborting connection...");
+            controller.abort();
+        }, 3000);
+
         deepgramConnection.connect();
-        await deepgramConnection.waitForOpen();
+        await waitForOpenOrAbort(deepgramConnection, controller.signal);
 
         // Stream some audio from a file
-        const audioStream = createReadStream("./examples/spacewalk.wav");
-        audioStream.on("data", (chunk) => {
+        audioStream = createReadStream("./examples/spacewalk.wav");
+        audioStream.on("data", (chunk: Buffer) => {
             deepgramConnection.sendMedia(chunk);
         });
 
-        // Simulate the user stopping the session after a short delay.
-        // Aborting tears the connection down for good: the socket closes,
-        // reconnection is disabled, and internal listeners are removed.
-        setTimeout(() => {
-            console.log("Stopping session, aborting connection...");
-            controller.abort();
-            console.log("Connection aborted; no reconnect will occur.");
-            process.exit(0);
-        }, 3000);
+        await connectionClosed;
+        console.log("Connection aborted; no reconnect will occur.");
     } catch (error) {
-        console.error("Error setting up connection:", error);
-        process.exit(1);
+        if (controller.signal.aborted) {
+            console.log("Connection attempt aborted; no reconnect will occur.");
+        } else {
+            console.error("Error setting up connection:", error);
+            process.exitCode = 1;
+        }
+    } finally {
+        clearTimeout(abortTimer);
+        audioStream?.destroy();
     }
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ This directory contains comprehensive examples demonstrating how to use the Deep
 - **07-transcription-live-websocket.js** - Live transcription via WebSocket
 - **08-transcription-captions.js** - Convert transcriptions to WebVTT/SRT captions
 - **22-transcription-advanced-options.js** - Advanced transcription options
+- **37-abortsignal-cancellation.js** - Safely cancel a WebSocket connection with AbortSignal
 
 ### Voice Agent
 - **09-voice-agent.js** - Voice Agent configuration and usage

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ This directory contains comprehensive examples demonstrating how to use the Deep
 - **26-transcription-live-websocket-v2.ts** - Live transcription via WebSocket V2
 - **38-transcription-flux-eot.ts** - Flux end-of-turn tuning
 - **39-transcription-flux-force-end-turn.ts** - Manual Flux turn finalization
+- **40-abortsignal-cancellation.ts** - Safely cancel a WebSocket connection with AbortSignal
 
 ### Voice Agent
 - **09-voice-agent.ts** - Voice Agent configuration and usage


### PR DESCRIPTION
## Summary

Documents the current `abortSignal` behavior for all real-time clients and adds a runnable cancellation example.

- Covers `listen.v1`, `listen.v2`, `agent.v1`, `speak.v1`, and `speak.v2`.
- Explains that abort stops the pending or active transport and disables automatic reconnection.
- Clarifies that abort can fire `close`, does not clear callbacks registered with `connection.on()`, and does not directly settle `waitForOpen()`.
- Provides a `waitForOpenOrAbort()` helper for applications that can cancel while connecting.
- Adds `examples/40-abortsignal-cancellation.ts` with bounded cancellation, stream/timer cleanup, and no forced successful process exit.
- Updates Makefile help, run-all behavior, individual targets, and the example catalog for examples 1-40.

## Scope

This covers the AbortSignal documentation portion of #507. A public `removeAllListeners()` or equivalent callback-disposal API remains out of scope and is not presented as existing behavior.

## Verification

- [x] Runtime probe confirms abort disables reconnection.
- [x] Runtime probe confirms abort can fire `close`, retains registered user callbacks, and leaves a bare `waitForOpen()` pending.
- [x] `waitForOpenOrAbort()` removes its signal listener and rejects when cancellation wins the race.
- [x] Example 40 passes strict standalone TypeScript checking.
- [x] Makefile and catalog contain unique entries and targets for examples 1-40.
- [x] Repository formatting check passes for the new example.
- [x] `git diff --check` passes.

## Files changed

- `README.md`
- `examples/40-abortsignal-cancellation.ts`
- `examples/README.md`
- `Makefile`