### PR TITLE
fix(websocket): default binaryType to arraybuffer for Bun

### DIFF
--- a/src/CustomClient.ts
+++ b/src/CustomClient.ts
@@ -461,7 +461,7 @@ class TransportWebSocketAdapter {
     private _retryCount = -1;
     private _shouldReconnect = true;
     private _connectLock = false;
-    private _binaryType: BinaryType = "blob";
+    private _binaryType: BinaryType = "arraybuffer";
     private _closeCalled = false;
     private _messageQueue: DeepgramTransportMessage[] = [];
     private _connectTimeout: ReturnType<typeof setTimeout> | undefined;

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -83,7 +83,9 @@ export class ReconnectingWebSocket {
     private _connectTimeout: any;
     private _shouldReconnect = true;
     private _connectLock = false;
-    private _binaryType: BinaryType = "blob";
+    // Prefer ArrayBuffer: Bun's `ws` rejects `binaryType = "blob"`, while
+    // ArrayBuffer is accepted by browsers, Node `ws`, and Bun.
+    private _binaryType: BinaryType = "arraybuffer";
     private _closeCalled = false;
     private _messageQueue: ReconnectingWebSocket.Message[] = [];
 


### PR DESCRIPTION
## Summary
- Default WebSocket `binaryType` to `"arraybuffer"` instead of `"blob"` so Bun's `ws` (which rejects `"blob"`) can open streaming connections.
- Same default on the transport adapter in `CustomClient` for consistency.

## Test plan
- [x] Simulated Bun setter: `"blob"` → `Invalid binaryType: blob`; `"arraybuffer"` → accepted.

Fixes #525
