### PR TITLE
fix(websocket): default binaryType to arraybuffer for Bun compatibility

### DIFF
--- a/examples/09-voice-agent.ts
+++ b/examples/09-voice-agent.ts
@@ -41,9 +41,9 @@ async function voiceAgent() {
             // Check message type
             if (data.type === "ConversationText") {
                 console.log("Conversation text:", data);
-            } else if (typeof data === "string") {
-                // Audio data comes as string
-                console.log("Audio received (length):", data.length);
+            } else if (data instanceof Blob) {
+                // Audio data is delivered as a Blob
+                console.log("Audio received (bytes):", data.size);
             } else {
                 console.log("Message:", data);
             }

--- a/examples/36-agent-inject-message.ts
+++ b/examples/36-agent-inject-message.ts
@@ -67,7 +67,8 @@ async function agentInjectMessage() {
                 console.log("Agent started speaking");
             } else if (data.type === "AgentAudioDone") {
                 console.log("Agent finished speaking");
-            } else if (data instanceof Uint8Array || Buffer.isBuffer(data)) {
+            } else if (data instanceof Blob) {
+                // Audio data is delivered as a Blob
                 console.log("Audio data received");
             } else {
                 console.log("Message:", data);

--- a/src/CustomClient.ts
+++ b/src/CustomClient.ts
@@ -980,9 +980,13 @@ function setupBinaryHandling(
                 // If JSON parsing fails, pass the raw string
                 eventHandlers.message?.(event.data);
             }
-        } else {
-            // Binary data - pass through as-is
+        } else if (event.data instanceof Blob) {
+            // Already a Blob - pass through as-is.
             eventHandlers.message?.(event.data);
+        } else {
+            // Binary arrives as an ArrayBuffer (the socket uses binaryType "arraybuffer").
+            // Wrap it in a Blob so consumers always receive a Blob, regardless of runtime.
+            eventHandlers.message?.(new Blob([event.data as BlobPart]));
         }
     };
 
@@ -1150,7 +1154,7 @@ async function createWebSocketConnection({
     const wsOptions = getWebSocketOptions(_headers, normalizedProtocols);
 
     // Create and return the ReconnectingWebSocket
-    return new ReconnectingWebSocket({
+    const socket = new ReconnectingWebSocket({
         url,
         protocols: wsOptions.protocols ?? [],
         queryParameters: queryParams,
@@ -1165,6 +1169,14 @@ async function createWebSocketConnection({
         },
         abortSignal,
     });
+
+    // Use the "arraybuffer" binaryType: some runtimes reject "blob" and throw when the socket
+    // opens. Set here (not in the generated core socket) so it survives regeneration; the
+    // socket is startClosed, so this applies before the underlying socket is created. Inbound
+    // binary is wrapped back into a Blob in setupBinaryHandling to keep the payload type
+    // consistent for consumers.
+    socket.binaryType = "arraybuffer";
+    return socket;
 }
 
 /**

--- a/tests/unit/websocket-wrappers.test.ts
+++ b/tests/unit/websocket-wrappers.test.ts
@@ -364,4 +364,18 @@ describe("WebSocket binaryType default", () => {
         expect(connection.socket.binaryType).toBe("arraybuffer");
         connection.close();
     });
+
+    it("listen.v2 connection defaults binaryType to arraybuffer", async () => {
+        const client = makeClient();
+        const connection = await client.listen.v2.createConnection({ model: "flux-general-en" });
+        expect(connection.socket.binaryType).toBe("arraybuffer");
+        connection.close();
+    });
+
+    it("speak.v2 connection defaults binaryType to arraybuffer", async () => {
+        const client = makeClient();
+        const connection = await client.speak.v2.createConnection({ model: "flux-alexis-en" });
+        expect(connection.socket.binaryType).toBe("arraybuffer");
+        connection.close();
+    });
 });

--- a/tests/unit/websocket-wrappers.test.ts
+++ b/tests/unit/websocket-wrappers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
 import { ReconnectingWebSocket } from "../../src/core/websocket/ws";
+import { DeepgramClient } from "../../src";
 
 // Global cleanup to ensure no lingering timeouts
 afterAll(() => {
@@ -246,9 +247,11 @@ describe("WebSocket wrapper functionality", () => {
                     } catch (error) {
                         eventHandlers.message?.(event.data);
                     }
-                } else {
-                    // Binary data - pass through as-is
+                } else if (event.data instanceof Blob) {
                     eventHandlers.message?.(event.data);
+                } else {
+                    // Binary is normalized to a Blob before delivery.
+                    eventHandlers.message?.(new Blob([event.data]));
                 }
             };
 
@@ -266,12 +269,12 @@ describe("WebSocket wrapper functionality", () => {
             binaryAwareHandler(invalidEvent);
             expect(eventHandlers.message).toHaveBeenCalledWith("invalid");
 
-            // Test with binary data
+            // Test with binary data - delivered as a Blob regardless of the inbound type
             const binaryEvent = new MessageEvent("message", {
                 data: new ArrayBuffer(10),
             });
             binaryAwareHandler(binaryEvent);
-            expect(eventHandlers.message).toHaveBeenCalledWith(expect.any(ArrayBuffer));
+            expect(eventHandlers.message).toHaveBeenCalledWith(expect.any(Blob));
         });
 
         it("should correctly implement preventDuplicateEventListeners pattern", () => {
@@ -319,5 +322,46 @@ describe("WebSocket wrapper functionality", () => {
             socketAny._closeCalled = true;
             socket.close();
         });
+    });
+});
+
+/**
+ * The socket must default to binaryType "arraybuffer": some runtimes (e.g. Bun's bundled
+ * `ws`) throw on binaryType "blob" and take down the connection on open. These tests use the
+ * real client factory (no fake timers, no network — the sockets are created startClosed) so a
+ * regression that reintroduces the "blob" default is caught.
+ */
+describe("WebSocket binaryType default", () => {
+    function makeClient() {
+        return new DeepgramClient({
+            maxRetries: 0,
+            apiKey: "test",
+            environment: {
+                base: "https://example.com",
+                production: "ws://localhost:1",
+                agent: "ws://localhost:1",
+            },
+        });
+    }
+
+    it("speak.v1 connection defaults binaryType to arraybuffer", async () => {
+        const client = makeClient();
+        const connection = await client.speak.v1.createConnection({ model: "aura-2-thalia-en" });
+        expect(connection.socket.binaryType).toBe("arraybuffer");
+        connection.close();
+    });
+
+    it("listen.v1 connection defaults binaryType to arraybuffer", async () => {
+        const client = makeClient();
+        const connection = await client.listen.v1.createConnection({ model: "nova-3" });
+        expect(connection.socket.binaryType).toBe("arraybuffer");
+        connection.close();
+    });
+
+    it("agent.v1 connection defaults binaryType to arraybuffer", async () => {
+        const client = makeClient();
+        const connection = await client.agent.v1.createConnection();
+        expect(connection.socket.binaryType).toBe("arraybuffer");
+        connection.close();
     });
 });

--- a/tests/wire/websocket/binary-audio-handling.test.ts
+++ b/tests/wire/websocket/binary-audio-handling.test.ts
@@ -52,7 +52,7 @@ describe("WebSocket binary audio data handling", () => {
                 .build();
         });
 
-        it("should receive binary audio data as ArrayBuffer, not empty object", async () => {
+        it("should receive binary audio data as a Blob, not empty object", async () => {
             const tracker = new WebSocketEventTracker();
             const receivedData: any[] = [];
 
@@ -120,19 +120,16 @@ describe("WebSocket binary audio data handling", () => {
             // Check each message type
             expect(receivedData[0]).toMatchObject({ type: "Metadata" });
 
-            // Binary audio should be ArrayBuffer or Blob (depending on environment), NOT empty object {}
-            // In Node.js with the ws library, binary data comes as Blob by default
-            const isBinaryType = (data: any) => data instanceof ArrayBuffer || data instanceof Blob;
-            const getBinarySize = (data: any) => (data instanceof ArrayBuffer ? data.byteLength : data?.size);
+            // The wrapped socket normalizes inbound binary to a Blob before delivery, so
+            // consumers receive a Blob on every runtime (never an empty object {}).
+            expect(receivedData[1]).toBeInstanceOf(Blob);
+            expect((receivedData[1] as Blob).size).toBe(1024);
 
-            expect(isBinaryType(receivedData[1])).toBe(true);
-            expect(getBinarySize(receivedData[1])).toBe(1024);
+            expect(receivedData[2]).toBeInstanceOf(Blob);
+            expect((receivedData[2] as Blob).size).toBe(2048);
 
-            expect(isBinaryType(receivedData[2])).toBe(true);
-            expect(getBinarySize(receivedData[2])).toBe(2048);
-
-            expect(isBinaryType(receivedData[3])).toBe(true);
-            expect(getBinarySize(receivedData[3])).toBe(512);
+            expect(receivedData[3]).toBeInstanceOf(Blob);
+            expect((receivedData[3] as Blob).size).toBe(512);
 
             expect(receivedData[4]).toMatchObject({ type: "Flushed" });
 

--- a/tests/wire/websocket/speak-v2-tts.test.ts
+++ b/tests/wire/websocket/speak-v2-tts.test.ts
@@ -173,9 +173,9 @@ describe("Speak v2 (Flux) WebSocket TTS streaming", () => {
             expect(connected).toMatchObject({ type: "Connected", request_id: "req-123" });
 
             // Exactly 3 binary audio frames arrived as binary (NOT parsed/dropped as JSON,
-            // and NOT duplicated by a listener bug).
-            const isBinary = (d: any) => d instanceof ArrayBuffer || d instanceof Blob;
-            const binaryFrames = receivedMessages.filter(isBinary);
+            // and NOT duplicated by a listener bug). The wrapped socket normalizes inbound
+            // binary to a Blob before delivery, so each frame is a Blob on every runtime.
+            const binaryFrames = receivedMessages.filter((d) => d instanceof Blob);
             expect(binaryFrames).toHaveLength(3);
 
             // Control messages parsed correctly


### PR DESCRIPTION
## Summary

Every WebSocket streaming client (`listen`/`speak`/`agent`) throws immediately under **Bun**, because the SDK's WebSocket layer sets `binaryType = "blob"`, which Bun's bundled `ws` rejects (`Invalid binaryType: blob`) the moment the socket opens. Node tolerates `"blob"`; Bun does not.

This defaults the socket's `binaryType` to `"arraybuffer"` — accepted by browsers, Node `ws`, and Bun alike.

## Why this shape

- **Regen-durable, no freeze needed.** The default is set in `CustomClient.ts` (the sole `ReconnectingWebSocket` factory, already frozen in `.fernignore`), *not* in the generated `core/websocket/ws.ts`. So Fern regeneration can't silently revert it, and no generated runtime file has to be frozen.
- **Non-breaking.** `"arraybuffer"` changes the raw inbound binary type from `Blob` to `ArrayBuffer`. To preserve the existing public contract, `setupBinaryHandling` now wraps inbound binary back into a `Blob` before delivery — so `on("message")` hands consumers a `Blob` on every runtime, exactly as before. No consumer-visible type change, no major bump.

## Tests

- **Unit:** asserts the `"arraybuffer"` default across `speak`/`listen`/`agent` v1 via the real client factory; corrects a stale copy-test.
- **Wire:** tightened to pin inbound audio as a `Blob` (was tolerant of `ArrayBuffer || Blob`).
- Full unit (594) + wire (141) suites green.
- **Live e2e (Node + Bun):** speak.v1 TTS delivers real audio as `Blob`, and listen/speak/agent all open without the crash on both runtimes. Verified via negative control that reverting the fix reproduces `Invalid binaryType: blob` under Bun.

Fixes #525

Co-authored-by: edenbuilds <279970382+edenbuilds@users.noreply.github.com>