### PR TITLE
fix: restore wire imports after test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,10 +320,20 @@ build:
 	node scripts/validate-esm-build.mjs
 
 test:
-	node scripts/fix-wire-test-imports.js
-	pnpm exec vitest --project unit --run
+	@cleanup() { \
+		test_status=$$?; \
+		trap - 0 INT TERM; \
+		node scripts/revert-wire-test-imports.js; \
+		cleanup_status=$$?; \
+		if [ $$test_status -ne 0 ]; then exit $$test_status; fi; \
+		exit $$cleanup_status; \
+	}; \
+	trap cleanup 0; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
+	node scripts/fix-wire-test-imports.js && \
+	pnpm exec vitest --project unit --run && \
 	pnpm exec vitest --project wire --run
-	node scripts/revert-wire-test-imports.js
 
 test-esm:
 	@printf "\033[1;36mRunning ESM build tests...\033[0m\n"


### PR DESCRIPTION
## Summary

- Run wire-import restoration from an exit trap so `make test` cleans up after success, test failure, interruption, or termination.
- Preserve the original test failure status.
- Surface a cleanup failure when the tests themselves passed.

## Verification

- `make build`
- `make test`
- `make lint`
- Forced `pnpm` to exit nonzero after the import rewrite and confirmed `make test` also failed while `git diff --exit-code -- tests/wire` remained clean.

No live API verification applies because this change only controls local test-runner cleanup.

Follow-up from the PR #538 agent-instructions review and PR #514 coverage review.